### PR TITLE
CMake build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,8 @@ else (DOXYGEN_FOUND)
   message("Doxygen needs to be installed to generate the doxygen documentation")
 endif (DOXYGEN_FOUND)
 
-find_package(CUDA)
-if(CUDA_FOUND)
-  enable_language(CUDA)
-endif()
+find_package(CUDA REQUIRED)
+enable_language(CUDA)
 
 find_package(GSL)
 find_package(LAPACK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,11 @@ find_package(Casacore REQUIRED)
 find_package(Boost)
 find_package(Eigen3 REQUIRED)
 
+# Our FindCasacore doesn't understand REQUIRED, so we need to manually check
+if (NOT CASACORE_FOUND)
+    message(FATAL_ERROR "Casacore not found, cannot proceed")
+endif()
+
 add_subdirectory(src/icrar/leap-accelerate)
 add_subdirectory(src/icrar/leap-accelerate-client)
 add_subdirectory(src/icrar/leap-accelerate-server)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,11 +82,6 @@ find_package(Casacore REQUIRED)
 find_package(Boost)
 find_package(Eigen3 REQUIRED)
 
-# Our FindCasacore doesn't understand REQUIRED, so we need to manually check
-if (NOT CASACORE_FOUND)
-    message(FATAL_ERROR "Casacore not found, cannot proceed")
-endif()
-
 add_subdirectory(src/icrar/leap-accelerate)
 add_subdirectory(src/icrar/leap-accelerate-client)
 add_subdirectory(src/icrar/leap-accelerate-server)

--- a/cmake/FindCasacore.cmake
+++ b/cmake/FindCasacore.cmake
@@ -137,9 +137,9 @@ if (NOT CASACORE_FOUND)
       message (STATUS "... libcasa_images      = ${CASACORE_IMAGES_LIBRARY}")
     endif (NOT CASACORE_FIND_QUIETLY)
   else (CASACORE_FOUND)
-    if (CASACORE_FIND_REQUIRED)
+    if (Casacore_FIND_REQUIRED)
       message (FATAL_ERROR "Could not find CASACORE!")
-    endif (CASACORE_FIND_REQUIRED)
+    endif (Casacore_FIND_REQUIRED)
   endif (CASACORE_FOUND)
 
   ## Compatibility variables

--- a/cmake/FindCasacore.cmake
+++ b/cmake/FindCasacore.cmake
@@ -48,18 +48,18 @@ if (NOT CASACORE_FOUND)
     )
 
   set (CASACORE_HEADERS
-    casa/Arrays.h
-    tables/Tables.h
-    mirlib/miriad.h
-    scimath/Fitting.h
-    measures/Measures.h
-    fits/FITS.h
-    coordinates/Coordinates.h
-    components/ComponentModels.h
-    lattices/Lattices.h
-    ms/MeasurementSets.h
-    images/Images.h
-    msfits/MSFits.h
+    casacore/casa/Arrays.h
+    casacore/tables/Tables.h
+    casacore/mirlib/miriad.h
+    casacore/scimath/Fitting.h
+    casacore/measures/Measures.h
+    casacore/fits/FITS.h
+    casacore/coordinates/Coordinates.h
+    casacore/components/ComponentModels.h
+    casacore/lattices/Lattices.h
+    casacore/ms/MeasurementSets.h
+    casacore/images/Images.h
+    casacore/msfits/MSFits.h
     )
   
   ##_____________________________________________________________________________
@@ -67,7 +67,7 @@ if (NOT CASACORE_FOUND)
   
   find_path (CASACORE_INCLUDES ${CASACORE_HEADERS}
     HINTS ${CASACORE_ROOT_DIR}
-    PATH_SUFFIXES include include/casacore
+    PATH_SUFFIXES include
     )
 
   ##_____________________________________________________________________________

--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -109,6 +109,7 @@ endif()
 
 if(CASA_ENABLED)
   target_link_libraries(${TARGET_NAME} ${CASACORE_LIBRARIES})
+  target_include_directories(${TARGET_NAME} PUBLIC ${CASACORE_INCLUDES})
 endif()
 if(BOOST_ENABLED)
   target_link_libraries(${TARGET_NAME} ${Boost_LIBRARIES})

--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -62,7 +62,6 @@ set(cuda_sources
 )
 
 # Libraries
-option(CUDA_ENABLED "Cuda Enabled" TRUE)
 option(CASA_ENABLED "Casa Enabled" TRUE)
 option(BOOST_ENABLED "Boost Enabled" TRUE)
 option(GSL_ENABLED "GSL Enabled" OFF)
@@ -102,10 +101,8 @@ if(USE_CUDA_EXTRA)
   #target_link_libraries(${TARGET_NAME} CUDA)
 endif()
 
-if(CUDA_ENABLED)
-  target_include_directories(${TARGET_NAME} PUBLIC "/usr/local/cuda/include")
-  target_include_directories(${TARGET_NAME} PUBLIC "/usr/local/cuda/include/crt")
-endif()
+target_include_directories(${TARGET_NAME} PUBLIC "/usr/local/cuda/include")
+target_include_directories(${TARGET_NAME} PUBLIC "/usr/local/cuda/include/crt")
 
 if(CASA_ENABLED)
   target_link_libraries(${TARGET_NAME} ${CASACORE_LIBRARIES})
@@ -150,7 +147,6 @@ install(
     include/icrar/${SOLUTION_NAME_LOWER}
 )
 
-unset(CUDA_ENABLED CACHE)
 unset(CASA_ENABLED CACHE)
 unset(BOOST_ENABLED CACHE)
 unset(GSL_ENABLED CACHE)


### PR DESCRIPTION
These are minor improvements to the cmake functionality. They allow to use casacore installations in non-standard locations, and state the CUDA dependency as a required one, better reflecting the current state of the code.