### PR TITLE
Fix Eigen includes

### DIFF
--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -104,7 +104,7 @@ target_include_directories(${TARGET_NAME} PUBLIC "/usr/local/cuda/include")
 target_include_directories(${TARGET_NAME} PUBLIC "/usr/local/cuda/include/crt")
 
 target_link_libraries(${TARGET_NAME} ${Boost_LIBRARIES})
-#target_link_libraries(${TARGET_NAME} Eigen3::Eigen) not supported on xenial
+target_link_libraries(${TARGET_NAME} Eigen3::Eigen)
 
 if(CASA_ENABLED)
   target_link_libraries(${TARGET_NAME} ${CASACORE_LIBRARIES})

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.h
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.h
@@ -24,7 +24,7 @@
 
 #include <casacore/ms/MeasurementSets.h>
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <string>
 #include <memory>

--- a/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h
+++ b/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h
@@ -29,7 +29,7 @@
 #define EIGEN_VECTORIZE_GPU 1
 #define EIGEN_CUDACC 1
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <casacore/ms/MeasurementSets.h>
 #include <casacore/casa/Arrays/Vector.h>

--- a/src/icrar/leap-accelerate/common/MVDirection.h
+++ b/src/icrar/leap-accelerate/common/MVDirection.h
@@ -20,7 +20,7 @@
  * MA 02111 - 1307  USA
  */
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/common/MVPosition.h
+++ b/src/icrar/leap-accelerate/common/MVPosition.h
@@ -20,7 +20,7 @@
  * MA 02111 - 1307  USA
  */
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/common/MVuvw.h
+++ b/src/icrar/leap-accelerate/common/MVuvw.h
@@ -20,7 +20,7 @@
  * MA 02111 - 1307  USA
  */
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/common/Tensor3X.h
+++ b/src/icrar/leap-accelerate/common/Tensor3X.h
@@ -20,8 +20,8 @@
  * MA 02111 - 1307  USA
  */
 
-#include <eigen3/Eigen/Core>
-//#include <eigen3/unsupported/Eigen/CXX11/Tensor>
+#include <Eigen/Core>
+//#include <unsupported/Eigen/CXX11/Tensor>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/cuda/device_vector.h
+++ b/src/icrar/leap-accelerate/cuda/device_vector.h
@@ -29,8 +29,8 @@
 #include <icrar/leap-accelerate/cuda/cuda_utils.cuh>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Dense>
 
 #include <vector>
 

--- a/src/icrar/leap-accelerate/math/Integration.h
+++ b/src/icrar/leap-accelerate/math/Integration.h
@@ -26,9 +26,9 @@
 #include <casacore/casa/Quanta/MVDirection.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
-//#include <eigen3/unsupported/Eigen/CXX11/Tensor>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+//#include <unsupported/Eigen/CXX11/Tensor>
 
 #include <boost/optional.hpp>
 

--- a/src/icrar/leap-accelerate/math/casa/matrix.h
+++ b/src/icrar/leap-accelerate/math/casa/matrix.h
@@ -26,7 +26,7 @@
 #include <casacore/casa/Arrays/Matrix.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/math/casa/matrix_invert.h
+++ b/src/icrar/leap-accelerate/math/casa/matrix_invert.h
@@ -25,9 +25,9 @@
 #include <icrar/leap-accelerate/math/cpu/matrix_invert.h>
 #include <casacore/casa/Arrays/Matrix.h>
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 
 #include <iostream>
 #include <string>

--- a/src/icrar/leap-accelerate/math/cpu/matrix3d.h
+++ b/src/icrar/leap-accelerate/math/cpu/matrix3d.h
@@ -24,9 +24,9 @@
 
 #include <casacore/casa/Arrays/Matrix.h>
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 
 namespace Eigen
 {

--- a/src/icrar/leap-accelerate/math/cpu/matrix_invert.h
+++ b/src/icrar/leap-accelerate/math/cpu/matrix_invert.h
@@ -25,9 +25,9 @@
 #include <casacore/casa/Arrays/Matrix.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/LU>
 
 #include <iostream>
 #include <string>

--- a/src/icrar/leap-accelerate/math/cpu/vector.cc
+++ b/src/icrar/leap-accelerate/math/cpu/vector.cc
@@ -23,7 +23,7 @@
 #include "vector.h"
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/math/cuda/vector.cuh
+++ b/src/icrar/leap-accelerate/math/cuda/vector.cuh
@@ -28,7 +28,7 @@
 #include <icrar/leap-accelerate/cuda/device_vector.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <casacore/casa/Arrays/Array.h>
 

--- a/src/icrar/leap-accelerate/math/cuda/vector.h
+++ b/src/icrar/leap-accelerate/math/cuda/vector.h
@@ -26,7 +26,7 @@
 #include <casacore/casa/Arrays/Array.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <vector>
 #include <array>

--- a/src/icrar/leap-accelerate/math/cuda/vector_eigen.cuh
+++ b/src/icrar/leap-accelerate/math/cuda/vector_eigen.cuh
@@ -29,7 +29,7 @@
 #include <casacore/casa/Arrays/Array.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <array>
 #include <vector>

--- a/src/icrar/leap-accelerate/math/linear_math_helper.h
+++ b/src/icrar/leap-accelerate/math/linear_math_helper.h
@@ -29,7 +29,7 @@
 #include <casacore/casa/Quanta/MVuvw.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <vector>
 
 namespace icrar

--- a/src/icrar/leap-accelerate/model/cuda/MetaDataCuda.h
+++ b/src/icrar/leap-accelerate/model/cuda/MetaDataCuda.h
@@ -38,7 +38,7 @@
 #include <casacore/casa/Arrays/Vector.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <boost/optional.hpp>
 

--- a/src/icrar/leap-accelerate/pch.h
+++ b/src/icrar/leap-accelerate/pch.h
@@ -27,12 +27,12 @@
 #include <casacore/casa/Arrays/Array.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/Sparse>
-#include <eigen3/Eigen/LU>
-#include <eigen3/Eigen/SVD>
-#include <eigen3/unsupported/Eigen/CXX11/Tensor>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+#include <Eigen/LU>
+#include <Eigen/SVD>
+#include <unsupported/Eigen/CXX11/Tensor>
 
 #include <cuda_runtime.h>
 

--- a/src/icrar/leap-accelerate/tests/math/casacore_eigen_tests.cc
+++ b/src/icrar/leap-accelerate/tests/math/casacore_eigen_tests.cc
@@ -30,8 +30,8 @@
 #include <casacore/casa/Arrays/Vector.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Sparse>
+#include <Eigen/Core>
+#include <Eigen/Sparse>
 
 #include <iostream>
 #include <array>

--- a/src/icrar/leap-accelerate/tests/math/cuda/cuda_vector_eigen_tests.cu
+++ b/src/icrar/leap-accelerate/tests/math/cuda/cuda_vector_eigen_tests.cu
@@ -26,7 +26,7 @@
 #include <icrar/leap-accelerate/math/cuda/vector_eigen.cuh>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <gtest/gtest.h>
 

--- a/src/icrar/leap-accelerate/tests/math/eigen_tests.cc
+++ b/src/icrar/leap-accelerate/tests/math/eigen_tests.cc
@@ -23,8 +23,8 @@
 #include <gtest/gtest.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Sparse>
+#include <Eigen/Core>
+#include <Eigen/Sparse>
 
 #include <iostream>
 #include <array>

--- a/src/icrar/leap-accelerate/tests/math/matrix_tests.cc
+++ b/src/icrar/leap-accelerate/tests/math/matrix_tests.cc
@@ -25,8 +25,8 @@
 #include <icrar/leap-accelerate/math/cpu/matrix_invert.h>
 
 #include <icrar/leap-accelerate/common/eigen_3_3_beta_1_2_support.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU> //Needed for Matrix::inverse()
+#include <Eigen/Core>
+#include <Eigen/LU> //Needed for Matrix::inverse()
 
 #include <icrar/leap-accelerate/tests/test_helper.h>
 #include <gtest/gtest.h>

--- a/src/icrar/leap-accelerate/tests/pch.h
+++ b/src/icrar/leap-accelerate/tests/pch.h
@@ -25,10 +25,10 @@
 #include <casacore/casa/Arrays/Matrix.h>
 #include <casacore/casa/Arrays/Array.h>
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU>
-#include <eigen3/Eigen/Sparse>
-#include <eigen3/Eigen/SVD>
+#include <Eigen/Core>
+#include <Eigen/LU>
+#include <Eigen/Sparse>
+#include <Eigen/SVD>
 
 #include <cuda_runtime.h>
 

--- a/src/icrar/leap-accelerate/tests/test_helper.h
+++ b/src/icrar/leap-accelerate/tests/test_helper.h
@@ -24,8 +24,8 @@
 
 #include <icrar/leap-accelerate/model/cuda/MetaDataCuda.h>
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Dense>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
There were two main problems with how Eigen was used in the project:
firstly, we were not linking yet to the Eigen3::Eigen target with cmake,
which didn't allow us to use arbitrary Eigen installations. On the other
hand the way Eigen headers were included wouldn't have allowed us anyway
to use these arbitrary Eigen installations anyway, as they included an
"eigen3" prefix that doesn't play well with the include directories
contained in the Eigen3::Eigen target.

This commit fixes the way Eigen headers are included by removing the
eigen3 prefix (`find src/ -type f -exec sed -i 's|eigen3/||' {} +`), and
by linking our library to the Eigen3::Eigen target.

This addresses #30.