### PR TITLE
Storing and displaying version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build/
 Testing/
 
 *.orig
+
+# Eclipse IDE files
+.project
+.cproject
+/bin/

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -1,0 +1,168 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+function(get_git_head_revision _refspecvar _hashvar)
+	set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+	set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	while(NOT EXISTS "${GIT_DIR}")	# .git dir not found, search parent directories
+		set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
+		get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
+		if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+			# We have reached the root directory, we are not in git
+			set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+			return()
+		endif()
+		set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+	endwhile()
+	# check if this is a submodule
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		file(READ ${GIT_DIR} submodule)
+		string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+		get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+		get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+	endif()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${GIT_DIR}/HEAD")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+		"${GIT_DATA}/grabRef.cmake"
+		@ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
+	set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		describe
+		${hash}
+		${ARGN}
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var} "${out}" PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(COMMAND
+		"${GIT_EXECUTABLE}"
+		diff-index --quiet HEAD --
+		WORKING_DIRECTORY
+		"${CMAKE_CURRENT_SOURCE_DIR}"
+		RESULT_VARIABLE
+		res
+		OUTPUT_VARIABLE
+		out
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(res EQUAL 0)
+		set(${_var} "CLEAN" PARENT_SCOPE)
+	else()
+		set(${_var} "DIRTY" PARENT_SCOPE)
+	endif()
+endfunction()

--- a/cmake/GetGitRevisionDescription.cmake.in
+++ b/cmake/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,41 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/src/icrar/leap-accelerate-cli/main.cc
+++ b/src/icrar/leap-accelerate-cli/main.cc
@@ -31,7 +31,9 @@
 #include <icrar/leap-accelerate/json/json_helper.h>
 #include <icrar/leap-accelerate/common/MVDirection.h>
 #include <icrar/leap-accelerate/core/compute_implementation.h>
+#include <icrar/leap-accelerate/core/git_revision.h>
 #include <icrar/leap-accelerate/core/logging.h>
+#include <icrar/leap-accelerate/core/version.h>
 
 #include <CLI/CLI.hpp>
 #include <boost/optional.hpp>
@@ -180,10 +182,22 @@ namespace icrar
 
 using namespace icrar;
 
+std::string version_information(const char *name)
+{
+    std::ostringstream os;
+    os << name << " version " << version() << '\n'
+       << "git revision " << git_sha1() << '\n';
+    os << "Has local git changes: " << std::boolalpha << git_has_local_changes()
+       << std::noboolalpha << '\n';
+    os << name << " built on " << __DATE__ << ' ' << __TIME__;
+    return os.str();
+}
+
 int main(int argc, char** argv)
 {
     icrar::log::Initialize();
     CLI::App app { "LEAP-Accelerate" };
+    app.set_version_flag("-v,--version", [&]() { return version_information(argv[0]); });
 
     //Parse Arguments
     Arguments rawArgs;

--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -2,6 +2,12 @@
 # to the source code
 configure_file(config.h.in config.h)
 
+include("${PROJECT_SOURCE_DIR}/cmake/GetGitRevisionDescription.cmake")
+get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+git_local_changes(GIT_HAS_LOCAL_CHANGES)
+set(git_revision_cc "${CMAKE_CURRENT_BINARY_DIR}/core/git_revision.cc")
+configure_file("core/git_revision.cc.in" "${git_revision_cc}" @ONLY)
+
 set(TARGET_NAME LeapAccelerate)
 
 set(public_headers
@@ -20,6 +26,8 @@ set(private_headers
     math/math.h
 )
 set(sources
+    ${git_revision_cc}
+
     exception/exception.cc
 
     ms/utils.cc

--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -41,6 +41,7 @@ set(sources
 
     core/compute_implementation.cc
     core/logging.cc
+    core/version.cc
 
     json/json_helper.cc
     

--- a/src/icrar/leap-accelerate/config.h.in
+++ b/src/icrar/leap-accelerate/config.h.in
@@ -1,2 +1,11 @@
 #define PROJECT_SOURCE_DIR "@PROJECT_SOURCE_DIR@/"
 #define PROJECT_BINARY_DIR "@CMAKE_BINARY_DIR@/bin/"
+
+/// The major version of this package
+#define LEAP_ACCELERATE_VERSION_MAJOR @LEAP-Accelerate_VERSION_MAJOR@
+
+/// The minor version of this package
+#define LEAP_ACCELERATE_VERSION_MINOR @LEAP-Accelerate_VERSION_MINOR@
+
+/// The patch version of this package
+#define LEAP_ACCELERATE_VERSION_PATCH @LEAP-Accelerate_VERSION_PATCH@

--- a/src/icrar/leap-accelerate/core/git_revision.cc.in
+++ b/src/icrar/leap-accelerate/core/git_revision.cc.in
@@ -1,0 +1,44 @@
+/**
+ * ICRAR - International Centre for Radio Astronomy Research
+ * (c) UWA - The University of Western Australia
+ * Copyright by UWA(in the framework of the ICRAR)
+ * All rights reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111 - 1307  USA
+ */
+
+/**
+ * @file
+ *
+ * Stores the git revision information
+ */
+
+#include <string>
+
+namespace icrar
+{
+
+std::string git_sha1()
+{
+	return "@GIT_SHA1@";
+}
+
+bool git_has_local_changes()
+{
+	return std::string("@GIT_HAS_LOCAL_CHANGES@") == "DIRTY";
+}
+
+} // namespace icrar

--- a/src/icrar/leap-accelerate/core/git_revision.h
+++ b/src/icrar/leap-accelerate/core/git_revision.h
@@ -1,0 +1,46 @@
+/**
+ * ICRAR - International Centre for Radio Astronomy Research
+ * (c) UWA - The University of Western Australia
+ * Copyright by UWA(in the framework of the ICRAR)
+ * All rights reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111 - 1307  USA
+ */
+
+/**
+ * @file
+ *
+ * Stores the version information of leap-accelerate
+ */
+
+#pragma once
+
+#include <string>
+
+namespace icrar
+{
+
+/**
+ * @return The git SHA1 value for the current source code commit.
+ */
+std::string git_sha1();
+
+/**
+ * @return Whether the local clone of the repository has uncommitted changes.
+ */
+bool git_has_local_changes();
+
+} // namespace icrar

--- a/src/icrar/leap-accelerate/core/version.cc
+++ b/src/icrar/leap-accelerate/core/version.cc
@@ -1,0 +1,45 @@
+/**
+ * ICRAR - International Centre for Radio Astronomy Research
+ * (c) UWA - The University of Western Australia
+ * Copyright by UWA(in the framework of the ICRAR)
+ * All rights reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111 - 1307  USA
+ */
+
+/**
+ * @file
+ *
+ * Stores the version information of leap-accelerate
+ */
+
+#include <string>
+
+#include "icrar/leap-accelerate/config.h"
+
+namespace icrar
+{
+
+static std::string _version = std::to_string(LEAP_ACCELERATE_VERSION_MAJOR) + "." +
+                              std::to_string(LEAP_ACCELERATE_VERSION_MINOR) + "." +
+                              std::to_string(LEAP_ACCELERATE_VERSION_PATCH);
+
+std::string version()
+{
+	return _version;
+}
+
+} // namespace icrar

--- a/src/icrar/leap-accelerate/core/version.h
+++ b/src/icrar/leap-accelerate/core/version.h
@@ -1,0 +1,42 @@
+/**
+ * ICRAR - International Centre for Radio Astronomy Research
+ * (c) UWA - The University of Western Australia
+ * Copyright by UWA(in the framework of the ICRAR)
+ * All rights reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111 - 1307  USA
+ */
+
+/**
+ * @file
+ *
+ * Stores the version information of leap-accelerate
+ */
+
+#pragma once
+
+#include <string>
+
+namespace icrar
+{
+
+/**
+ * Returns the version of this library as a single string
+ * @return The version of this library
+ */
+std::string version();
+
+} // namespace icrar


### PR DESCRIPTION
This pull request includes some additions around version information handling:

 * The information from the top-level `version.txt` file is now included into generated source code file which is then made available both to leap-accelerate itself and to projects compiling against it, both at compile time (via macro definitions) and runtime (via library-level functions)
 * The same is done, again automatically, for the git SHA1 commit id and a boolean attribute indicating if the source code tree contained or not local changes when the library was compiled
 * This information is finally displayed when running `LeapAccelerateCLI` with `-v` or `--version`
 * Additionally, the date/time of the build is also displayed by `LeapAccelerateCLI`

A sample output looks like this:

```bash
$> bin/x86_64/bin/LeapAccelerateCLI --version
bin/x86_64/bin/LeapAccelerateCLI version 0.4.0
git revision c13da0ce6ba207c65fb8cd0016f9dcdef19f7db6
Has local git changes: false
bin/x86_64/bin/LeapAccelerateCLI built on Oct 26 2020 16:25:26
```

This was recently requested by @mdolensk.