### PR TITLE
Trace Matrix Values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 option(WERROR "Warnings as Errors" ON)
+option(TRACE "Trace Data Values" OFF)
 
 # Project configuration, specifying version, languages,
 # and the C++ standard to use for the whole project
@@ -21,7 +22,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "G
   if(WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
   endif()
+endif()
 
+if(TRACE)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DTRACE")
 endif()
 
 add_definitions(-DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/testdata")

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ LEAP-Accelerate includes:
 
 `cd Debug`
 
-`cmake ../../ -DCMAKE_CXX_FLAGS_DEBUG=-O1 -DCMAKE_BUILD_TYPE=Debug`
+`cmake ../../ -DCMAKE_CXX_FLAGS_DEBUG="-g -O1" -DCMAKE_BUILD_TYPE=Debug`
+
+(with tracing):
+
+`cmake ../../ -DCMAKE_CXX_FLAGS_DEBUG="-g -O1" -DTRACE=ON -DCMAKE_BUILD_TYPE=Debug`
 
 #### Release
 

--- a/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.cu
+++ b/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.cu
@@ -37,6 +37,8 @@
 #include <icrar/leap-accelerate/cuda/cuda_info.h>
 #include <icrar/leap-accelerate/core/logging.h>
 
+#include <icrar/leap-accelerate/common/eigen_extensions.h>
+
 #include <casacore/measures/Measures/MDirection.h>
 #include <casacore/casa/Quanta/MVDirection.h>
 #include <casacore/casa/Quanta/MVuvw.h>
@@ -149,6 +151,16 @@ namespace cuda
         deviceMetadata.ToHost(hostMetadata);
         
         BOOST_LOG_TRIVIAL(info) << "Calibrating on cpu";
+        BOOST_LOG_TRIVIAL(trace) << "avg_data: " << pretty_matrix(hostMetadata.avg_data);
+#ifdef TRACE
+        {
+            std::ofstream file;
+            file.open("avg_data.txt");
+            file << hostMetadata.avg_data << std::endl;
+            file.close();
+        }
+#endif
+
         auto avg_data_angles = hostMetadata.avg_data.unaryExpr([](std::complex<double> c) -> Radians { return std::arg(c); });
 
         // TODO: reference antenna should be included and set to 0?

--- a/src/icrar/leap-accelerate/common/eigen_extensions.h
+++ b/src/icrar/leap-accelerate/common/eigen_extensions.h
@@ -1,0 +1,106 @@
+
+/**
+*    ICRAR - International Centre for Radio Astronomy Research
+*    (c) UWA - The University of Western Australia
+*    Copyright by UWA (in the framework of the ICRAR)
+*    All rights reserved
+*
+*    This library is free software; you can redistribute it and/or
+*    modify it under the terms of the GNU Lesser General Public
+*    License as published by the Free Software Foundation; either
+*    version 2.1 of the License, or (at your option) any later version.
+*
+*    This library is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+*    Lesser General Public License for more details.
+*
+*    You should have received a copy of the GNU Lesser General Public
+*    License along with this library; if not, write to the Free Software
+*    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+*    MA 02111-1307  USA
+*/
+
+#pragma once
+
+#include <Eigen/Core>
+
+#include <iomanip>
+#include <iostream>
+#include <vector>
+#include <functional>
+#include <type_traits>
+
+constexpr int pretty_width = 12;
+
+namespace icrar
+{
+    template<typename RowVector>
+    void pretty_row(const RowVector& row, std::stringstream& ss)
+    {
+        ss << "[";
+
+        if(row.cols() < 7)
+        {
+            for(int c = 0; c < row.cols(); ++c)
+            {
+                ss << std::setw(pretty_width) << row(c);
+                if(c != row.cols() - 1) { ss << " "; }
+            }
+        }
+        else
+        {
+            for(int c = 0; c < 3; ++c)
+            {
+                ss << std::setw(pretty_width) << row(c) << " ";
+            }
+            ss << std::setw(pretty_width) << "..." << " ";
+            for(int c = row.cols() - 3; c < row.cols(); ++c)
+            {
+                ss << std::setw(pretty_width) << row(c);
+                if(c != row.cols() - 1) { ss << " "; }
+            }
+        }
+        ss << "]";
+    }
+
+    template<typename Matrix>
+    std::string pretty_matrix(const Matrix& value)
+    {
+        std::stringstream ss;
+        ss << "Eigen::Matrix [ " << value.rows() << ", " << value.cols() << "]\n";
+
+        if(value.rows() < 7)
+        {
+            for(int r = 0; r < value.rows(); ++r)
+            {
+                pretty_row(value(r, Eigen::all), ss);
+                if(r != value.rows() - 1) { ss << "\n"; }
+            }
+        }
+        else
+        {
+            for(int r = 0; r < 3; ++r)
+            {
+                pretty_row(value(r, Eigen::all), ss);
+                if(r != 2) { ss << "\n"; }
+            }
+            
+            ss << "\n[";
+            for(int c = 0; c < 7; ++c)
+            {
+                ss << std::setw(pretty_width) << "...";
+                if(c != 6) { ss << " "; }
+            }
+            ss << "]\n";
+            
+            for(int r = value.rows() - 3; r < value.rows(); ++r)
+            {
+                pretty_row(value(r, Eigen::all), ss);
+                if(r != value.rows() - 1) { ss << "\n"; }
+            }
+        }
+
+        return ss.str();
+    }
+}

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -28,8 +28,8 @@
 #include <icrar/leap-accelerate/math/math.h>
 #include <icrar/leap-accelerate/math/casacore_helper.h>
 #include <icrar/leap-accelerate/exception/exception.h>
+#include <icrar/leap-accelerate/common/eigen_extensions.h>
 #include <icrar/leap-accelerate/core/logging.h>
-
 
 namespace icrar
 {
@@ -148,13 +148,51 @@ namespace cpu
 
         BOOST_LOG_TRIVIAL(info) << "Calculating PhaseMatrix A1";
         std::tie(m_A1, m_I1) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), 0);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_A1);
+#ifdef TRACE
+        {
+            std::ofstream file;
+            file.open("A1.txt");
+            file << m_A1 << std::endl;
+            file.close();
+        }
+#endif
+
         BOOST_LOG_TRIVIAL(info) << "Calculating PhaseMatrix A";
         std::tie(m_A, m_I) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), -1);
-        
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_A);
+#ifdef TRACE
+        {
+            std::ofstream file;
+            file.open("A.txt");
+            file << m_A << std::endl;
+            file.close();
+        }
+#endif
+
         BOOST_LOG_TRIVIAL(info) << "Inverting PhaseMatrix A1";
         m_Ad1 = icrar::cpu::PseudoInverse(m_A1);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_Ad1);
+#ifdef TRACE
+        {
+            std::ofstream file;
+            file.open("Ad1.txt");
+            file << m_Ad1 << std::endl;
+            file.close();
+        }
+#endif
+
         BOOST_LOG_TRIVIAL(info) << "Inverting PhaseMatrix A";
         m_Ad = icrar::cpu::PseudoInverse(m_A);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_Ad);
+#ifdef TRACE
+        {
+            std::ofstream file;
+            file.open("Ad.txt");
+            file << m_Ad1 << std::endl;
+            file.close();
+        }
+#endif
 
         if(!(m_Ad1 * m_A1).isApprox(Eigen::MatrixXd::Identity(m_A.cols(), m_A.cols()), 0.001))
         {

--- a/src/icrar/leap-accelerate/tests/math/eigen_tests.cc
+++ b/src/icrar/leap-accelerate/tests/math/eigen_tests.cc
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include <icrar/leap-accelerate/common/eigen_extensions.h>
+
 #include <Eigen/Core>
 #include <Eigen/Sparse>
 
@@ -84,8 +86,33 @@ public:
 
         ASSERT_EQ(expected, m3);
     }
+
+    void test_matrix_pretty()
+    {
+        auto mat = Eigen::MatrixXd(5,5);
+        mat <<
+        0, 1, 2, 3, 4,
+        5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19,
+        20, 21, 22, 23, 24;
+
+        mat = Eigen::MatrixXd(10,10);
+        mat <<
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+        30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+        40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+        50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+        60, 61, 62, 63, 64, 65, 66, 67, 68, 69,
+        70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+        80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+        90, 91, 92, 93, 94, 95, 96, 97, 98, 99;
+    }
 };
 
 TEST_F(eigen_tests, test_matrix_size) { test_matrix_size(); }
 TEST_F(eigen_tests, test_matrix_eigen) { test_matrix_eigen(); }
 TEST_F(eigen_tests, test_matrix_multiply) { test_matrix_multiply(); }
+TEST_F(eigen_tests, test_matrix_pretty) { test_matrix_pretty(); }


### PR DESCRIPTION
This changeset adds logging of matrix values in debug mode, and dumping entire matrices to file when TRACE is defined using the following build configuration.

`cmake ../../ -DCMAKE_CXX_FLAGS_DEBUG="-g -O1" -DTRACE=ON -DCMAKE_BUILD_TYPE=Debug`

This will create and overwrite files A1.txt, Ad1.txt, avg_data.txt after each run.