### PR TITLE
Reduce memory allocations

### DIFF
--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
@@ -262,8 +262,6 @@ std::pair<Eigen::MatrixXd, Eigen::VectorXi> PhaseMatrixFunction(
         }
 
         Eigen::MatrixXd A = Eigen::MatrixXd::Zero(a1.size() + 1, std::max(a1.maxCoeff(), a2.maxCoeff()) + 1);
-        int STATIONS = A.cols(); //TODO verify correctness
-
         Eigen::VectorXi I = Eigen::VectorXi(a1.size() + 1);
         I.setConstant(-1);
 
@@ -289,20 +287,11 @@ std::pair<Eigen::MatrixXd, Eigen::VectorXi> PhaseMatrixFunction(
 
         A(k, refAnt) = 1;
         k++;
-        
-        auto Atemp = Eigen::MatrixXd(k, STATIONS);
-        Atemp = A(Eigen::seqN(0, k), Eigen::seqN(0, STATIONS));
-        A.resize(0,0);
-        A = Atemp;
 
-        auto Itemp = Eigen::VectorXi(k);
-        Itemp = I(Eigen::seqN(0, k));
-        
-        I.resize(0);
-        I = Itemp;
-    
+        A.conservativeResize(k, Eigen::NoChange);
+        I.conservativeResize(k);
 
-        return std::make_pair(A, I);
+        return std::make_pair(std::move(A), std::move(I));
     }
 }
 }

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -134,8 +134,8 @@ namespace cpu
             if(time[i] == epoch) nEpochs++;
         }
         auto epochIndices = casacore::Slice(0, nEpochs, 1); //TODO assuming epoch indices are sorted
-        casacore::Vector<std::int32_t> a1 = msmc->antenna1().getColumn()(epochIndices); 
-        casacore::Vector<std::int32_t> a2 = msmc->antenna2().getColumn()(epochIndices);
+        casacore::Vector<std::int32_t> a1 = msmc->antenna1().getColumnRange(epochIndices);
+        casacore::Vector<std::int32_t> a2 = msmc->antenna2().getColumnRange(epochIndices);
 
         // if(a1.size() != m_constants.nbaselines)
         // {


### PR DESCRIPTION
These are just two commits reducing the amount of memory allocations performed by the `icrar::cpu::MetaData` function. They don't have an effect on the MaxRSS of the application though, which is dominated by the matrix inversion code, but is still a gain.