### PR TITLE
Cuda Constant Device Buffer

### DIFF
--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -141,7 +141,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Calculating PhaseMatrix A1";
         std::tie(m_A1, m_I1) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), 0);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << "A1 Matrix " << pretty_matrix(m_A1);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_A1);
         {
             std::ofstream file;
             file.open("A1.txt");
@@ -153,7 +153,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Calculating PhaseMatrix A";
         std::tie(m_A, m_I) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), -1);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << "A Matrix " << pretty_matrix(m_A);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_A);
         {
             std::ofstream file;
             file.open("A.txt");
@@ -165,7 +165,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Inverting PhaseMatrix A1";
         m_Ad1 = icrar::cpu::PseudoInverse(m_A1);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << "Ad1 Matrix " << pretty_matrix(m_Ad1);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_Ad1);
         {
             std::ofstream file;
             file.open("Ad1.txt");
@@ -177,7 +177,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Inverting PhaseMatrix A";
         m_Ad = icrar::cpu::PseudoInverse(m_A);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << "Ad Matrix " << pretty_matrix(m_Ad);
+        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_Ad);
         {
             std::ofstream file;
             file.open("Ad.txt");

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -141,7 +141,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Calculating PhaseMatrix A1";
         std::tie(m_A1, m_I1) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), 0);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_A1);
+        BOOST_LOG_TRIVIAL(trace) << "A1 Matrix " << pretty_matrix(m_A1);
         {
             std::ofstream file;
             file.open("A1.txt");
@@ -153,7 +153,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Calculating PhaseMatrix A";
         std::tie(m_A, m_I) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), -1);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_A);
+        BOOST_LOG_TRIVIAL(trace) << "A Matrix " << pretty_matrix(m_A);
         {
             std::ofstream file;
             file.open("A.txt");
@@ -165,7 +165,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Inverting PhaseMatrix A1";
         m_Ad1 = icrar::cpu::PseudoInverse(m_A1);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_Ad1);
+        BOOST_LOG_TRIVIAL(trace) << "Ad1 Matrix " << pretty_matrix(m_Ad1);
         {
             std::ofstream file;
             file.open("Ad1.txt");
@@ -177,7 +177,7 @@ namespace cpu
         BOOST_LOG_TRIVIAL(info) << "Inverting PhaseMatrix A";
         m_Ad = icrar::cpu::PseudoInverse(m_A);
 #ifdef TRACE
-        BOOST_LOG_TRIVIAL(trace) << pretty_matrix(m_Ad);
+        BOOST_LOG_TRIVIAL(trace) << "Ad Matrix " << pretty_matrix(m_Ad);
         {
             std::ofstream file;
             file.open("Ad.txt");

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.h
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.h
@@ -54,6 +54,7 @@ namespace icrar
 namespace cuda
 {
     class DeviceMetaData;
+    class ConstantMetaData;
 }
 }
 
@@ -163,6 +164,7 @@ namespace cpu
         bool operator==(const MetaData& rhs) const;
 
         friend class icrar::cuda::DeviceMetaData;
+        friend class icrar::cuda::ConstantMetaData;
     };
     }
 }

--- a/src/icrar/leap-accelerate/model/cuda/DeviceMetaData.cu
+++ b/src/icrar/leap-accelerate/model/cuda/DeviceMetaData.cu
@@ -30,48 +30,91 @@ namespace icrar
 {
 namespace cuda
 {
+    ConstantMetaData::ConstantMetaData(
+            const icrar::cpu::Constants constants,
+            Eigen::MatrixXd A,
+            Eigen::VectorXi I,
+            Eigen::MatrixXd Ad,
+            Eigen::MatrixXd A1,
+            Eigen::VectorXi I1,
+            Eigen::MatrixXd Ad1)
+        : m_constants(constants)
+        , m_A(A)
+        , m_I(I)
+        , m_Ad(Ad)
+        , m_A1(A1)
+        , m_I1(I1)
+        , m_Ad1(Ad1) { }
+
+    void ConstantMetaData::ToHost(icrar::cpu::MetaData& host)
+    {
+        host.m_constants = m_constants;
+
+        m_A.ToHost(host.m_A);
+        m_I.ToHost(host.m_I);
+        m_Ad.ToHost(host.m_Ad);
+        m_A1.ToHost(host.m_A1);
+        m_I1.ToHost(host.m_I1);
+        m_Ad1.ToHost(host.m_Ad1);
+    }
+
     DeviceMetaData::DeviceMetaData(const cpu::MetaData& metadata)
-    : constants(metadata.GetConstants())
-    , UVW(metadata.GetUVW())
-    , oldUVW(metadata.GetOldUVW())
-    , dd(metadata.GetDD())
-    , direction(metadata.GetDirection())
-    , avg_data(metadata.GetAvgData())
-    , A(metadata.GetA())
-    , I(metadata.GetI())
-    , Ad(metadata.GetAd())
-    , A1(metadata.GetA1())
-    , I1(metadata.GetI1())
-    , Ad1(metadata.GetAd1())
+    : m_constantMetadata(std::make_shared<ConstantMetaData>(
+        metadata.GetConstants(),
+        metadata.GetA(),
+        metadata.GetI(),
+        metadata.GetAd(),
+        metadata.GetA1(),
+        metadata.GetI1(),
+        metadata.GetAd1()))
+    , m_oldUVW(metadata.GetOldUVW())
+    , m_UVW(metadata.GetUVW())
+    , m_dd(metadata.GetDD())
+    , m_direction(metadata.GetDirection())
+    , m_avg_data(metadata.GetAvgData())
     {
     }
 
-    const icrar::cpu::Constants& DeviceMetaData::GetConstants()
+    DeviceMetaData::DeviceMetaData(std::shared_ptr<ConstantMetaData> constantMetadata, const icrar::cpu::MetaData& metadata)
+    : m_constantMetadata(constantMetadata)
+    , m_oldUVW(metadata.GetOldUVW())
+    , m_UVW(metadata.GetUVW())
+    , m_dd(metadata.GetDD())
+    , m_direction(metadata.GetDirection())
+    , m_avg_data(metadata.GetAvgData())
     {
-        return constants;
+
+    }
+
+    const icrar::cpu::Constants& DeviceMetaData::GetConstants() const
+    {
+        return m_constantMetadata->GetConstants();
+    }
+
+    void DeviceMetaData::SetDirection(const icrar::MVDirection& direction)
+    {
+        m_direction = direction;
+    }
+
+    void DeviceMetaData::SetAvgData(int v)
+    {
+        cudaMemset(m_avg_data.Get(), v, m_avg_data.GetSize());
     }
 
     void DeviceMetaData::ToHost(cpu::MetaData& metadata) const
     {
-        metadata.m_constants = constants;
+        m_constantMetadata->ToHost(metadata);
 
-        A.ToHost(metadata.m_A);
-        I.ToHost(metadata.m_I);
-        Ad.ToHost(metadata.m_Ad);
-        A1.ToHost(metadata.m_A1);
-        I1.ToHost(metadata.m_I1);
-        Ad1.ToHost(metadata.m_Ad1);
-
-        oldUVW.ToHost(metadata.m_oldUVW);
-        UVW.ToHost(metadata.m_UVW);
-        metadata.m_direction = direction;
-        metadata.m_dd = dd;
-        avg_data.ToHost(metadata.m_avg_data);
+        m_oldUVW.ToHost(metadata.m_oldUVW);
+        m_UVW.ToHost(metadata.m_UVW);
+        metadata.m_direction = m_direction;
+        metadata.m_dd = m_dd;
+        m_avg_data.ToHost(metadata.m_avg_data);
     }
 
     void DeviceMetaData::AvgDataToHost(Eigen::MatrixXcd& host) const
     {
-        avg_data.ToHost(host);
+        m_avg_data.ToHost(host);
     }
 
     cpu::MetaData DeviceMetaData::ToHost() const
@@ -79,7 +122,7 @@ namespace cuda
         //TODO: tidy up using a constructor for now
         //TODO: casacore::MVuvw and casacore::MVDirection not safe to copy to cuda
         std::vector<icrar::MVuvw> uvwTemp;
-        UVW.ToHost(uvwTemp);
+        m_UVW.ToHost(uvwTemp);
         cpu::MetaData result = cpu::MetaData();
         ToHost(result);
         return result;

--- a/src/icrar/leap-accelerate/model/cuda/DeviceMetaData.h
+++ b/src/icrar/leap-accelerate/model/cuda/DeviceMetaData.h
@@ -42,6 +42,7 @@
 
 #include <boost/optional.hpp>
 
+#include <memory>
 #include <iostream>
 #include <string>
 #include <memory>
@@ -56,20 +57,39 @@ namespace cuda
 {
     /**
      * Container of uniform gpu buffers available to all cuda
-     * threads and are immutable.
+     * threads that are const/immutable per calibration.
      */
-    class UniformMetaData
+    class ConstantMetaData
     {
+        icrar::cpu::Constants m_constants;
+        
+        device_matrix<double> m_A;
+        device_vector<int> m_I;
+        device_matrix<double> m_Ad;
+
+        device_matrix<double> m_A1;
+        device_vector<int> m_I1;
+        device_matrix<double> m_Ad1;
+
     public:
-        icrar::cpu::Constants constants;
-        
-        device_matrix<double> A;
-        device_vector<int> I;
-        device_matrix<double> Ad;
-        
-        device_matrix<double> A1;
-        device_vector<int> I1;
-        device_matrix<double> Ad1;
+        ConstantMetaData(
+            const icrar::cpu::Constants constants,
+            Eigen::MatrixXd A,
+            Eigen::VectorXi I,
+            Eigen::MatrixXd Ad,
+            Eigen::MatrixXd A1,
+            Eigen::VectorXi I1,
+            Eigen::MatrixXd Ad1);
+
+        const icrar::cpu::Constants& GetConstants() const { return m_constants; }
+        const device_matrix<double>& GetA() const { return m_A; } 
+        const device_vector<int>& GetI() const { return m_I; }
+        const device_matrix<double>& GetAd() const { return m_Ad; }
+        const device_matrix<double>& GetA1() const { return m_A1; }
+        const device_vector<int>& GetI1() const { return m_I1; }
+        const device_matrix<double>& GetAd1() const { return m_Ad1; }
+
+        void ToHost(icrar::cpu::MetaData& host);
     };
 
     /**
@@ -80,23 +100,14 @@ namespace cuda
     {
         DeviceMetaData();
 
-        icrar::cpu::Constants constants;
- 
-        device_matrix<double> A;
-        device_vector<int> I;
-        device_matrix<double> Ad;
-        
-        device_matrix<double> A1;
-        device_vector<int> I1;
-        device_matrix<double> Ad1;
-
+        std::shared_ptr<ConstantMetaData> m_constantMetadata; // Constant buffer, never null
 
         // Metadata that is zero'd before execution
-        device_vector<icrar::MVuvw> oldUVW;
-        device_vector<icrar::MVuvw> UVW;
-        icrar::MVDirection direction;
-        Eigen::Matrix3d dd;
-        device_matrix<std::complex<double>> avg_data;
+        device_vector<icrar::MVuvw> m_oldUVW;
+        device_vector<icrar::MVuvw> m_UVW;
+        icrar::MVDirection m_direction;
+        Eigen::Matrix3d m_dd;
+        device_matrix<std::complex<double>> m_avg_data;
 
     public:
         /**
@@ -105,15 +116,27 @@ namespace cuda
          * 
          * @param metadata 
          */
+        [[deprecated]]
         DeviceMetaData(const icrar::cpu::MetaData& metadata);
+        
+        /**
+         * @brief Construct a new Device MetaData object from the equivalent object on CPU memory. This copies to
+         * all device buffers
+         * 
+         * @param metadata 
+         */
+        DeviceMetaData(std::shared_ptr<ConstantMetaData> uniformMetadata, const icrar::cpu::MetaData& metadata);
 
-        const icrar::cpu::Constants& GetConstants();
+        const icrar::cpu::Constants& GetConstants() const;
 
-        const device_vector<icrar::MVuvw>& GetOldUVW() const { return oldUVW; }
-        const device_vector<icrar::MVuvw>& GetUVW() const { return UVW; }
-        const icrar::MVDirection& GetDirection() const { return direction; }
-        const Eigen::Matrix3d& GetDD() const { return dd; }
-        const device_matrix<std::complex<double>>& GetAvgData() { return avg_data; };
+        const device_vector<icrar::MVuvw>& GetOldUVW() const { return m_oldUVW; }
+        const device_vector<icrar::MVuvw>& GetUVW() const { return m_UVW; }
+        const icrar::MVDirection& GetDirection() const { return m_direction; }
+        const Eigen::Matrix3d& GetDD() const { return m_dd; }
+        const device_matrix<std::complex<double>>& GetAvgData() { return m_avg_data; };
+
+        void SetDirection(const icrar::MVDirection& direction);
+        void SetAvgData(int v);
 
         void ToHost(icrar::cpu::MetaData& host) const;
         icrar::cpu::MetaData ToHost() const;


### PR DESCRIPTION
I've noticed that for multiple directions cuda copies large constant matrices from the host to device for each direction which is unnecessary as this buffer can be reused between directions.

From my previous SKA run this improves performance for 9 directions:
wall time: 58.43s -> 52.81s