### PR TITLE
Add Config File Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ or
 #### Recommended Versions Compatibility
 
 * g++ 9.3.0
-* cuda 10.1
+* cuda 10.1 (nvidia-driver-440)
 * boost 1.71.0
 * casacore 3.1.2
 * eigen 3.3.90

--- a/src/icrar/leap-accelerate-cli/Arguments.cc
+++ b/src/icrar/leap-accelerate-cli/Arguments.cc
@@ -38,14 +38,13 @@ namespace icrar
     {
         auto args = CLIArguments();
         args.source = InputType::FILENAME;
-        args.filePath = boost::none; // Measurement set filepath
-        args.configFilePath = boost::none; // Config filepath
+        args.filePath = boost::none;
+        args.configFilePath = boost::none;
         args.outFilePath = boost::none;
 
         args.stations = boost::none;
         args.directions = boost::none;
         args.computeImplementation = std::string("cpu");
-        
         args.mwaSupport = false;
         args.readAutocorrelations = true;
         args.verbosity = static_cast<int>(log::DEFAULT_VERBOSITY);
@@ -217,14 +216,14 @@ namespace icrar
         return m_verbosity;
     }
 
-    Arguments ParseConfig(const std::string& configFilepath)
+    Arguments ArgumentsValidated::ParseConfig(const std::string& configFilepath)
     {
         Arguments args;
         ParseConfig(configFilepath, args);
         return args;
     }
 
-    void ParseConfig(const std::string& configFilepath, Arguments& args)
+    void ArgumentsValidated::ParseConfig(const std::string& configFilepath, Arguments& args)
     {
         auto ifs = std::ifstream(configFilepath);
         rapidjson::IStreamWrapper isw(ifs);

--- a/src/icrar/leap-accelerate-cli/Arguments.cc
+++ b/src/icrar/leap-accelerate-cli/Arguments.cc
@@ -1,0 +1,116 @@
+/**
+ * ICRAR - International Centre for Radio Astronomy Research
+ * (c) UWA - The University of Western Australia
+ * Copyright by UWA(in the framework of the ICRAR)
+ * All rights reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111 - 1307  USA
+ */
+
+#include "Arguments.h"
+
+#include <icrar/leap-accelerate/exception/exception.h>
+#include <icrar/leap-accelerate/json/json_helper.h>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+
+#include <fstream>
+#include <iostream>
+
+namespace icrar
+{
+    Config ParseConfig(const std::string& configFilepath)
+    {
+        Config args;
+        ParseConfig(configFilepath, args);
+        return args;
+    }
+
+    void ParseConfig(const std::string& configFilepath, Config& args)
+    {
+        auto ifs = std::ifstream(configFilepath);
+        rapidjson::IStreamWrapper isw(ifs);
+        rapidjson::Document doc;
+        doc.ParseStream(isw);
+
+        if(!doc.IsObject())
+        {
+            throw icrar::json_exception("expected config to be an object", __FILE__, __LINE__);
+        }
+        for(auto it = doc.MemberBegin(); it != doc.MemberEnd(); ++it)
+        {
+            if(!it->name.IsString())
+            {
+                throw icrar::json_exception("config keys must be a string", __FILE__, __LINE__);
+            }
+            else
+            {
+                std::string key = it->name.GetString();
+
+                if(key == "source")
+                {
+                    //args.source = it->value.GetInt(); //TODO: change to string
+                }
+                else if(key == "filePath")
+                {
+                    args.filePath = it->value.GetString();
+                }
+                else if(key == "configFilePath")
+                {
+                    throw icrar::json_exception("recursive config detected", __FILE__, __LINE__);
+                }
+                else if(key == "outFilePath")
+                {
+                    args.outFilePath = it->value.GetString();
+                }
+                else if(key == "stations")
+                {
+                    args.stations = it->value.GetInt();
+                }
+                else if(key == "directions")
+                {
+                    args.directions = ParseDirections(it->value.GetString());
+                }
+                else if(key == "implementation")
+                {
+                    ComputeImplementation i;
+                    if(!TryParseComputeImplementation(it->value.GetString(), i))
+                    {
+                        throw icrar::json_exception("invalid implementation string", __FILE__, __LINE__);
+                    }
+                    else
+                    {
+                        args.implementation = i;
+                    }
+                }
+                else if(key == "mwaSupport")
+                {
+                    args.mwaSupport = it->value.GetBool();
+                }
+                else if(key == "readAutoCorrelations")
+                {
+                    args.mwaSupport = it->value.GetBool();
+                }
+                else if(key == "verbosity")
+                {
+                    args.verbosity = it->value.GetBool();
+                }
+            }
+        }
+    }
+}

--- a/src/icrar/leap-accelerate-cli/Arguments.h
+++ b/src/icrar/leap-accelerate-cli/Arguments.h
@@ -55,14 +55,13 @@ namespace icrar
     struct CLIArguments
     {
         boost::optional<InputType> source;
-        boost::optional<std::string> filePath; // Measurement set filepath
-        boost::optional<std::string> configFilePath; // Config filepath
+        boost::optional<std::string> filePath;
+        boost::optional<std::string> configFilePath;
         boost::optional<std::string> outFilePath;
 
         boost::optional<std::string> stations;
         boost::optional<std::string> directions;
         boost::optional<std::string> computeImplementation;
-        
         boost::optional<bool> mwaSupport;
         boost::optional<bool> readAutocorrelations;
         boost::optional<int> verbosity;
@@ -77,15 +76,14 @@ namespace icrar
         Arguments() {}
         Arguments(CLIArguments&& args);
 
-        boost::optional<InputType> source;
-        boost::optional<std::string> filePath;
-        boost::optional<std::string> configFilePath;
-        boost::optional<std::string> outFilePath;
+        boost::optional<InputType> source; // MeasurementSet source type
+        boost::optional<std::string> filePath; // MeasurementSet filepath
+        boost::optional<std::string> configFilePath; // Optional config filepath
+        boost::optional<std::string> outFilePath; // Calibration output file, print to terminal if empty
 
         boost::optional<int> stations;
         boost::optional<std::vector<icrar::MVDirection>> directions;
         boost::optional<ComputeImplementation> computeImplementation;
-        
         boost::optional<bool> mwaSupport;
         boost::optional<bool> readAutocorrelations;
         boost::optional<icrar::log::Verbosity> verbosity;
@@ -99,17 +97,17 @@ namespace icrar
         /**
          * Constants
          */
-        InputType m_source; // MeasurementSet source type
+        InputType m_source;
         boost::optional<std::string> m_filePath; // MeasurementSet filepath
-        boost::optional<std::string> m_configFilePath = boost::none; // Config filepath
-        boost::optional<std::string> m_outFilePath = boost::none; // Calibration output filepath
+        boost::optional<std::string> m_configFilePath; // Config filepath
+        boost::optional<std::string> m_outFilePath; // Calibration output filepath
 
-        boost::optional<int> m_stations; // Overriden number of stations
-        std::vector<MVDirection> m_directions;
-        ComputeImplementation m_computeImplementation;
-        bool m_mwaSupport;
-        bool m_readAutocorrelations;
-        icrar::log::Verbosity m_verbosity;
+        boost::optional<int> m_stations; // Overriden number of stations (will be removed in a later release)
+        std::vector<MVDirection> m_directions; // Calibration directions
+        ComputeImplementation m_computeImplementation; // Specifies the implementation for calibration computation
+        bool m_mwaSupport; // Negates baselines when enabled
+        bool m_readAutocorrelations; // Adjusts the number of baselines calculation to include autocorrelations
+        icrar::log::Verbosity m_verbosity; // Defines logging level for std::out
 
         /**
          * Resources
@@ -138,21 +136,22 @@ namespace icrar
         ComputeImplementation GetComputeImplementation() const;
 
         icrar::log::Verbosity GetVerbosity() const;
-    };
 
-    /**
-     * @brief Converts a JSON file to a config
-     * 
-     * @param configFilepath 
-     * @return Config 
-     */
-    Arguments ParseConfig(const std::string& configFilepath);
-    
-    /**
-     * @brief 
-     * 
-     * @param configFilepath 
-     * @param args 
-     */
-    void ParseConfig(const std::string& configFilepath, Arguments& args);
+    private:
+        /**
+         * @brief Converts a JSON file to a config
+         * 
+         * @param configFilepath 
+         * @return Config 
+         */
+        Arguments ParseConfig(const std::string& configFilepath);
+        
+        /**
+         * @brief Converts a JSON file to a config
+         * 
+         * @param configFilepath 
+         * @param args 
+         */
+        void ParseConfig(const std::string& configFilepath, Arguments& args);
+    };
 }

--- a/src/icrar/leap-accelerate-cli/Arguments.h
+++ b/src/icrar/leap-accelerate-cli/Arguments.h
@@ -1,0 +1,75 @@
+/**
+ * ICRAR - International Centre for Radio Astronomy Research
+ * (c) UWA - The University of Western Australia
+ * Copyright by UWA(in the framework of the ICRAR)
+ * All rights reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111 - 1307  USA
+ */
+
+#pragma once
+
+#include <icrar/leap-accelerate/common/MVDirection.h>
+#include <icrar/leap-accelerate/core/compute_implementation.h>
+
+#include <boost/optional.hpp>
+#include <string>
+#include <vector>
+
+namespace icrar
+{
+    enum class InputType
+    {
+        STREAM,
+        FILENAME,
+        APACHE_ARROW
+    };
+
+    struct Arguments
+    {
+        boost::optional<InputType> source;
+        boost::optional<std::string> filePath; // Measurement set filepath
+        boost::optional<std::string> configFilePath; // Config filepath
+        boost::optional<std::string> outFilePath;
+
+        boost::optional<std::string> stations;
+        boost::optional<std::string> directions;
+        boost::optional<std::string> implementation;
+        
+        boost::optional<bool> mwaSupport;
+        boost::optional<bool> readAutocorrelations;
+        boost::optional<int> verbosity;
+    };
+
+    struct Config
+    {
+        boost::optional<InputType> source;
+        boost::optional<std::string> filePath; // Measurement set filepath
+        boost::optional<std::string> configFilePath; // Config filepath
+        boost::optional<std::string> outFilePath;
+
+        boost::optional<int> stations;
+        boost::optional<std::vector<icrar::MVDirection>> directions;
+        boost::optional<ComputeImplementation> implementation;
+        
+        boost::optional<bool> mwaSupport;
+        boost::optional<bool> readAutocorrelations;
+        boost::optional<int> verbosity;
+    };
+
+    Config ParseConfig(const std::string& configFilepath);
+    void ParseConfig(const std::string& configFilepath, Config& args);
+}

--- a/src/icrar/leap-accelerate-cli/CMakeLists.txt
+++ b/src/icrar/leap-accelerate-cli/CMakeLists.txt
@@ -3,13 +3,19 @@ set(TARGET_EXPORT leapaccelerate-targest)
 
 set(sources
   main.cc
+  Arguments.cc
 )
 
 include_directories(${CMAKE_SOURCE_DIR}/external/CLI11/include)
 
 # add the executable
-add_executable (${TARGET_NAME} main.cc)
-target_link_libraries (${TARGET_NAME} LeapAccelerate)
+add_executable(
+  ${TARGET_NAME}
+  ${sources}
+)
+target_link_libraries(${TARGET_NAME} LeapAccelerate)
+target_link_libraries(${TARGET_NAME} RapidJSON::RapidJSON)
+
 set_target_properties(${TARGET_NAME}
   PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"

--- a/src/icrar/leap-accelerate-cli/main.cc
+++ b/src/icrar/leap-accelerate-cli/main.cc
@@ -22,16 +22,12 @@
 
 #include <icrar/leap-accelerate-cli/Arguments.h>
 
-#include <icrar/leap-accelerate/model/casa/Integration.h>
-#include <icrar/leap-accelerate/model/casa/MetaData.h>
 #include <icrar/leap-accelerate/algorithm/casa/PhaseRotate.h>
 #include <icrar/leap-accelerate/algorithm/cpu/PhaseRotate.h>
 #include <icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h>
 
 #include <icrar/leap-accelerate/ms/MeasurementSet.h>
 #include <icrar/leap-accelerate/math/math_conversion.h>
-#include <icrar/leap-accelerate/common/MVDirection.h>
-#include <icrar/leap-accelerate/core/compute_implementation.h>
 #include <icrar/leap-accelerate/core/git_revision.h>
 #include <icrar/leap-accelerate/core/log/logging.h>
 #include <icrar/leap-accelerate/core/profiling/UsageReporter.h>

--- a/src/icrar/leap-accelerate-cli/main.cc
+++ b/src/icrar/leap-accelerate-cli/main.cc
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
     app.set_version_flag("--version", [&]() { return version_information(appName); });
 
     //Parse Arguments
-    CLIArguments rawArgs = CLIArguments();
+    CLIArguments rawArgs;
 
     //app.add_option("-i,--input-type", rawArgs.source, "Input source type");
     app.add_option("-s,--stations", rawArgs.stations, "Override number of stations to use in the measurement set");
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
     icrar::profiling::UsageReporter _;
     try
     {
-        ArgumentsValidated args = ArgumentsValidated(std::move(Arguments(std::move(rawArgs))));
+        ArgumentsValidated args = { Arguments(std::move(rawArgs)) };
 
         icrar::log::Initialize(args.GetVerbosity());
 

--- a/src/icrar/leap-accelerate-cli/tests/JSONHelperTests.cc
+++ b/src/icrar/leap-accelerate-cli/tests/JSONHelperTests.cc
@@ -20,7 +20,7 @@
  * MA 02111 - 1307  USA
  */
 
-#include <icrar/leap-accelerate/json/json_helper.h>
+#include <icrar/leap-accelerate/common/MVDirection.h>
 
 #include <icrar/leap-accelerate/tests/test_helper.h>
 #include <icrar/leap-accelerate/math/casacore_helper.h>

--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -50,12 +50,13 @@ set(sources
     math/cpu/vector.cc
 
     core/compute_implementation.cc
-    core/logging.cc
+    core/log/logging.cc
+    core/log/Verbosity.cc
     core/profiling/resource_usage.cc
     core/profiling/UsageReporter.cc
     core/version.cc
 
-    json/json_helper.cc
+    common/MVDirection.cc
     
     algorithm/casa/PhaseRotate.cc
     algorithm/cpu/PhaseRotate.cc

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
@@ -33,7 +33,7 @@
 
 #include <icrar/leap-accelerate/common/eigen_extensions.h>
 
-#include <icrar/leap-accelerate/core/logging.h>
+#include <icrar/leap-accelerate/core/log/logging.h>
 #include <icrar/leap-accelerate/core/profiling/timer.h>
 
 #include <casacore/ms/MeasurementSets/MeasurementSet.h>

--- a/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.cu
+++ b/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.cu
@@ -35,7 +35,7 @@
 #include <icrar/leap-accelerate/math/cuda/vector.h>
 #include <icrar/leap-accelerate/math/cpu/vector.h>
 #include <icrar/leap-accelerate/cuda/cuda_info.h>
-#include <icrar/leap-accelerate/core/logging.h>
+#include <icrar/leap-accelerate/core/log/logging.h>
 #include <icrar/leap-accelerate/core/profiling/timer.h>
 
 #include <icrar/leap-accelerate/common/eigen_extensions.h>

--- a/src/icrar/leap-accelerate/common/MVDirection.cc
+++ b/src/icrar/leap-accelerate/common/MVDirection.cc
@@ -20,7 +20,7 @@
  * MA 02111 - 1307  USA
  */
 
-#include "json_helper.h"
+#include "MVDirection.h"
 
 #include <icrar/leap-accelerate/math/math_conversion.h>
 #include <icrar/leap-accelerate/exception/exception.h>
@@ -30,11 +30,15 @@ using namespace rapidjson;
 
 namespace icrar
 {
-    std::vector<icrar::MVDirection> ParseDirections(const std::string json)
+    std::vector<icrar::MVDirection> ParseDirections(const std::string& json)
     {
         Document doc;
         doc.Parse(json.c_str());
+        return ParseDirections(doc);
+    }
 
+    std::vector<icrar::MVDirection> ParseDirections(const rapidjson::Value& doc)
+    {
         //Validate Schema
         if(!doc.IsArray())
         {

--- a/src/icrar/leap-accelerate/common/MVDirection.h
+++ b/src/icrar/leap-accelerate/common/MVDirection.h
@@ -24,7 +24,24 @@
 
 #include <Eigen/Core>
 
+#include <rapidjson/document.h>
+#include <vector>
+
 namespace icrar
 {
     using MVDirection = Eigen::RowVector3d;
+
+    /**
+     * @brief Parses a json string to a collection of MVDirections
+     * 
+     * @param json 
+     * @return std::vector<icrar::MVDirection> 
+     */
+    std::vector<icrar::MVDirection> ParseDirections(const std::string& json);
+
+    /**
+     * @brief Parses a json object to a collection of MVDirections
+     * 
+     */
+    std::vector<icrar::MVDirection> ParseDirections(const rapidjson::Value& doc);
 }

--- a/src/icrar/leap-accelerate/common/eigen_extensions.h
+++ b/src/icrar/leap-accelerate/common/eigen_extensions.h
@@ -32,7 +32,7 @@
 #include <functional>
 #include <type_traits>
 
-#include "icrar/leap-accelerate/core/logging.h"
+#include "icrar/leap-accelerate/core/log/logging.h"
 
 constexpr int pretty_width = 12;
 

--- a/src/icrar/leap-accelerate/core/compute_implementation.cc
+++ b/src/icrar/leap-accelerate/core/compute_implementation.cc
@@ -25,6 +25,16 @@
 
 namespace icrar
 {
+    ComputeImplementation ParseComputeImplementation(std::string value)
+    {
+        ComputeImplementation i;
+        if(!TryParseComputeImplementation(value, i))
+        {
+            throw std::invalid_argument("value");
+        }
+        return i;
+    }
+
     /**
      * @return true if value was converted succesfully, false otherwise
      */

--- a/src/icrar/leap-accelerate/core/compute_implementation.h
+++ b/src/icrar/leap-accelerate/core/compute_implementation.h
@@ -33,6 +33,8 @@ namespace icrar
         cuda = 2, // Compute implementation on gpu use nvidia cuda
     };
 
+    ComputeImplementation ParseComputeImplementation(std::string value);
+
     /**
      * @return true if value was converted succesfully, false otherwise
      */

--- a/src/icrar/leap-accelerate/core/log/Verbosity.cc
+++ b/src/icrar/leap-accelerate/core/log/Verbosity.cc
@@ -20,47 +20,60 @@
  * MA 02111 - 1307  USA
  */
 
-#include <icrar/leap-accelerate/core/compute_implementation.h>
-#include <icrar/leap-accelerate/core/log/logging.h>
+#include <icrar/leap-accelerate/core/log/Verbosity.h>
 
 namespace icrar
 {
-    ComputeImplementation ParseComputeImplementation(std::string value)
+namespace log
+{
+    Verbosity ParseVerbosity(const std::string& value)
     {
-        ComputeImplementation i;
-        if(!TryParseComputeImplementation(value, i))
+        Verbosity e;
+        if(!TryParseVerbosity(value, e))
         {
             throw std::invalid_argument("value");
         }
-        return i;
+        return e;
     }
 
-    /**
-     * @return true if value was converted succesfully, false otherwise
-     */
-    bool TryParseComputeImplementation(std::string value, ComputeImplementation& out)
+    bool TryParseVerbosity(const std::string& value, Verbosity& out)
     {
-        if(value == "casa")
+        string lower_value = value;
+        std::transform(
+            value.begin(), value.end(), lower_value.begin(), 
+            [](unsigned char c){ return std::tolower(c); });
+
+        if(lower_value == "fatal")
         {
-            out = ComputeImplementation::casa;
+            out = Verbosity::FATAL;
             return true;
         }
-        else if(value == "eigen")
+        else if(lower_value == "error")
         {
-            LOG(info) << "argument 'eigen' deprecated, use 'cpu' instead";
-            out = ComputeImplementation::cpu;
+            out = Verbosity::ERROR;
             return true;
         }
-        else if(value == "cpu")
+        else if(lower_value == "warn")
         {
-            out = ComputeImplementation::cpu;
+            out = Verbosity::WARN;
             return true;
         }
-        else if(value == "cuda")
+        else if(lower_value == "info")
         {
-            out = ComputeImplementation::cuda;
+            out = Verbosity::INFO;
+            return true;
+        }
+        else if(lower_value == "debug")
+        {
+            out = Verbosity::DEBUG;
+            return true;
+        }
+        else if(lower_value == "trace")
+        {
+            out = Verbosity::TRACE;
             return true;
         }
         return false;
     }
+}
 }

--- a/src/icrar/leap-accelerate/core/log/Verbosity.h
+++ b/src/icrar/leap-accelerate/core/log/Verbosity.h
@@ -22,27 +22,33 @@
 
 #pragma once
 
-#include <boost/log/trivial.hpp>
+#include <string>
 
 namespace icrar
 {
 namespace log
 {
-
-    /// The default verbosity level with which the logging system is initialized
-    constexpr int DEFAULT_VERBOSITY = 3;
+    enum class Verbosity
+    {
+        FATAL = 0,
+        ERROR = 1,
+        WARN = 2,
+        INFO = 3,
+        DEBUG = 4,
+        TRACE = 5
+    };
+    
+    /**
+     * @brief Parses string argument into an enum, throws an exception otherwise.
+     * 
+     * @param value 
+     * @return ComputeImplementation 
+     */
+    Verbosity ParseVerbosity(const std::string& value);
 
     /**
-     * @brief Initializes logging singletons
-     * @param verbosity The verbosity to initialize the library with, higher
-     * values yield more verbose output.
+     * @return true if value was converted succesfully, false otherwise.
      */
-    void Initialize(int verbosity=DEFAULT_VERBOSITY);
-
-    /// The logging level set on the application
-    extern ::boost::log::trivial::severity_level logging_level;
+    bool TryParseVerbosity(const std::string& value, Verbosity& out);
 }
 }
-
-#define LOG(X) BOOST_LOG_TRIVIAL(X)
-#define LOG_ENABLED(lvl) (::boost::log::trivial::severity_level::lvl >= ::icrar::log::logging_level)

--- a/src/icrar/leap-accelerate/core/log/logging.cc
+++ b/src/icrar/leap-accelerate/core/log/logging.cc
@@ -34,7 +34,7 @@
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/file.hpp>
 
-#include "icrar/leap-accelerate/core/logging.h"
+#include "icrar/leap-accelerate/core/log/logging.h"
 
 namespace icrar
 {
@@ -47,7 +47,7 @@ namespace log
      * @brief Initializes logging
      * 
      */
-    void Initialize(int verbosity)
+    void Initialize(Verbosity verbosity)
     {
         boost::log::core::get()->add_global_attribute("TimeStamp", boost::log::attributes::local_clock());
 
@@ -70,9 +70,7 @@ namespace log
         );
 
         // low verbosity values mean higher severity levels
-        verbosity = std::min(std::max(verbosity, 0), 5);
-        verbosity = 5 - verbosity;
-        logging_level = boost::log::trivial::severity_level(verbosity);
+        logging_level = boost::log::trivial::severity_level(5 - static_cast<int>(verbosity));
         boost::log::core::get()->set_filter([](const boost::log::attribute_value_set &s)
         {
             return s["Severity"].extract<boost::log::trivial::severity_level>() >= logging_level;

--- a/src/icrar/leap-accelerate/core/log/logging.h
+++ b/src/icrar/leap-accelerate/core/log/logging.h
@@ -20,12 +20,29 @@
  * MA 02111 - 1307  USA
  */
 
-#include <icrar/leap-accelerate/common/MVDirection.h>
+#pragma once
 
-#include <rapidjson/document.h>
-#include <vector>
+#include <icrar/leap-accelerate/core/log/Verbosity.h>
+#include <boost/log/trivial.hpp>
 
 namespace icrar
 {
-    std::vector<icrar::MVDirection> ParseDirections(const std::string json);
+namespace log
+{
+    /// The default verbosity level with which the logging system is initialized
+    constexpr Verbosity DEFAULT_VERBOSITY = Verbosity::INFO;
+
+    /**
+     * @brief Initializes logging singletons
+     * @param verbosity The verbosity to initialize the library with, higher
+     * values yield more verbose output.
+     */
+    void Initialize(Verbosity verbosity=DEFAULT_VERBOSITY);
+
+    /// The logging level set on the application
+    extern ::boost::log::trivial::severity_level logging_level;
 }
+}
+
+#define LOG(X) BOOST_LOG_TRIVIAL(X)
+#define LOG_ENABLED(lvl) (::boost::log::trivial::severity_level::lvl >= ::icrar::log::logging_level)

--- a/src/icrar/leap-accelerate/core/profiling/UsageReporter.cc
+++ b/src/icrar/leap-accelerate/core/profiling/UsageReporter.cc
@@ -23,7 +23,7 @@
 #include <exception>
 #include <iostream>
 
-#include "icrar/leap-accelerate/core/logging.h"
+#include "icrar/leap-accelerate/core/log/logging.h"
 #include "icrar/leap-accelerate/core/profiling/resource_usage.h"
 #include "icrar/leap-accelerate/core/profiling/UsageReporter.h"
 

--- a/src/icrar/leap-accelerate/core/profiling/timer.h
+++ b/src/icrar/leap-accelerate/core/profiling/timer.h
@@ -24,7 +24,7 @@
 
 #include <icrar/leap-accelerate/math/math_conversion.h>
 #include <icrar/leap-accelerate/core/ioutils.h>
-#include <icrar/leap-accelerate/core/logging.h>
+#include <icrar/leap-accelerate/core/log/logging.h>
 
 #include <chrono>
 #include <ostream>

--- a/src/icrar/leap-accelerate/model/cpu/Integration.cc
+++ b/src/icrar/leap-accelerate/model/cpu/Integration.cc
@@ -27,7 +27,7 @@
 #include <icrar/leap-accelerate/common/Tensor3X.h>
 
 #include <icrar/leap-accelerate/core/ioutils.h>
-#include <icrar/leap-accelerate/core/logging.h>
+#include <icrar/leap-accelerate/core/log/logging.h>
 
 namespace icrar
 {

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -30,7 +30,7 @@
 #include <icrar/leap-accelerate/exception/exception.h>
 #include <icrar/leap-accelerate/common/eigen_extensions.h>
 #include <icrar/leap-accelerate/core/ioutils.h>
-#include <icrar/leap-accelerate/core/logging.h>
+#include <icrar/leap-accelerate/core/log/logging.h>
 
 namespace icrar
 {


### PR DESCRIPTION
Andreas has mentioned that configuration needs to be done via a configuration file to avoid large scripts with string regex to call leap-accelerate-cli. Here I've added three stages of configuration/argument loading in preference (ordered from highest to lowest):
* CLIArgs
* ConfigArgs
* DefaultArgs

From this change I'll add unit tests around the new behaviour before adding output file support.