### PR TITLE
Support trace macro

### DIFF
--- a/src/icrar/leap-accelerate/core/log/Verbosity.cc
+++ b/src/icrar/leap-accelerate/core/log/Verbosity.cc
@@ -45,32 +45,32 @@ namespace log
 
         if(lower_value == "fatal")
         {
-            out = Verbosity::FATAL;
+            out = Verbosity::fatal;
             return true;
         }
         else if(lower_value == "error")
         {
-            out = Verbosity::ERROR;
+            out = Verbosity::error;
             return true;
         }
         else if(lower_value == "warn")
         {
-            out = Verbosity::WARN;
+            out = Verbosity::warn;
             return true;
         }
         else if(lower_value == "info")
         {
-            out = Verbosity::INFO;
+            out = Verbosity::info;
             return true;
         }
         else if(lower_value == "debug")
         {
-            out = Verbosity::DEBUG;
+            out = Verbosity::debug;
             return true;
         }
         else if(lower_value == "trace")
         {
-            out = Verbosity::TRACE;
+            out = Verbosity::trace;
             return true;
         }
         return false;

--- a/src/icrar/leap-accelerate/core/log/Verbosity.h
+++ b/src/icrar/leap-accelerate/core/log/Verbosity.h
@@ -30,12 +30,12 @@ namespace log
 {
     enum class Verbosity
     {
-        FATAL = 0,
-        ERROR = 1,
-        WARN = 2,
-        INFO = 3,
-        DEBUG = 4,
-        TRACE = 5
+        fatal = 0,
+        error = 1,
+        warn = 2,
+        info = 3,
+        debug = 4,
+        trace = 5
     };
     
     /**

--- a/src/icrar/leap-accelerate/core/log/logging.h
+++ b/src/icrar/leap-accelerate/core/log/logging.h
@@ -30,7 +30,7 @@ namespace icrar
 namespace log
 {
     /// The default verbosity level with which the logging system is initialized
-    constexpr Verbosity DEFAULT_VERBOSITY = Verbosity::INFO;
+    constexpr Verbosity DEFAULT_VERBOSITY = Verbosity::info;
 
     /**
      * @brief Initializes logging singletons


### PR DESCRIPTION
I've noticed that when TRACE is defined the verbosity enum fails to compile. Here I've just favoured lower-case enum literals.