### PR TITLE
Optional Cuda Support

### DIFF
--- a/.travis/before_install_xenial.sh
+++ b/.travis/before_install_xenial.sh
@@ -48,16 +48,13 @@ export PATH=$PATH:$CUDA_HOME/bin
 
 # Set Compiler Config
 sudo update-alternatives --remove-all gcc
-sudo update-alternatives --remove-all g++
-
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 10
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 20
-
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 20
-
 sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
 sudo update-alternatives --set cc /usr/bin/gcc
 
+sudo update-alternatives --remove-all g++
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 10
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 20
 sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
 sudo update-alternatives --set c++ /usr/bin/g++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+option(CUDA_ENABLED "Build with cuda support" OFF)
 option(WERROR "Warnings as Errors" ON)
 option(TRACE "Trace Data Values" OFF)
 
@@ -110,8 +111,10 @@ else (DOXYGEN_FOUND)
   message("Doxygen needs to be installed to generate the doxygen documentation")
 endif (DOXYGEN_FOUND)
 
-find_package(CUDA REQUIRED)
-enable_language(CUDA)
+if(CUDA_ENABLED)
+  find_package(CUDA)
+  enable_language(CUDA)
+endif()
 
 add_definitions(-DBOOST_ALL_DYN_LINK)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ or
 
 * https://askubuntu.com/questions/355565/how-do-i-install-the-latest-version-of-cmake-from-the-command-line
 * sudo apt-get install gcc g++ gdb doxygen casacore-dev libboost1.58-all-dev libgsl-dev
+* https://developer.nvidia.com/cuda-92-download-archive?target_os=Linux&target_arch=x86_64&target_distro=Ubuntu&target_version=1604&target_type=deblocal
 
 ### Recommended Versions Compatibility
 

--- a/src/icrar/leap-accelerate-cli/main.cc
+++ b/src/icrar/leap-accelerate-cli/main.cc
@@ -123,8 +123,12 @@ int main(int argc, char** argv)
         }
         case ComputeImplementation::cuda:
         {
+#ifdef CUDA_ENABLED
             cpu::CalibrateResult result = icrar::cuda::Calibrate(args.GetMeasurementSet(), args.GetDirections());
             cpu::PrintResult(result ,args.GetOutputStream());
+#else
+            throw exception("cuda build option required", __FILE__, __LINE__);
+#endif
             break;
         }
         }

--- a/src/icrar/leap-accelerate-cli/tests/E2EPerformanceTests.cc
+++ b/src/icrar/leap-accelerate-cli/tests/E2EPerformanceTests.cc
@@ -108,7 +108,9 @@ namespace icrar
             }
             else if(impl == ComputeImplementation::cuda)
             {
+#ifdef CUDA_ENABLED
                 auto result = cuda::Calibrate(*ms, ToDirectionVector(directions));
+#endif
             }
             else
             {
@@ -119,13 +121,19 @@ namespace icrar
 
     TEST_F(E2EPerformanceTests, MultiDirectionTestCasa) { MultiDirectionTest(ComputeImplementation::casa, "/mwa/1197638568-32.ms", 126, true); }
     TEST_F(E2EPerformanceTests, MultiDirectionTestCpu) { MultiDirectionTest(ComputeImplementation::cpu, "/mwa/1197638568-32.ms", 126, true); }
+#ifdef CUDA_ENABLED
     TEST_F(E2EPerformanceTests, MultiDirectionTestCuda) { MultiDirectionTest(ComputeImplementation::cuda, "/mwa/1197638568-32.ms", 126, true); }
+#endif
 
     // These measurements have flagged data removed and complete data for each timestep
     TEST_F(E2EPerformanceTests, MWACleanTestCpu) { MultiDirectionTest(ComputeImplementation::cpu, "/mwa/1197638568-split.ms", 126, true); }
+#ifdef CUDA_ENABLED
     TEST_F(E2EPerformanceTests, MWACleanTestCuda) { MultiDirectionTest(ComputeImplementation::cuda, "/mwa/1197638568-split.ms", 126, true); }
-    
+#endif
+
     // These measurements are clean and use a single timestep
     TEST_F(E2EPerformanceTests, SKACleanTestCpu) { MultiDirectionTest(ComputeImplementation::cpu, "/ska/SKA_LOW_SIM_short_EoR0_ionosphere_off_GLEAM.0001.ms", boost::none, false); }
+#ifdef CUDA_ENABLED
     TEST_F(E2EPerformanceTests, SKACleanTestCuda) { MultiDirectionTest(ComputeImplementation::cuda, "/ska/SKA_LOW_SIM_short_EoR0_ionosphere_off_GLEAM.0001.ms", boost::none, false); }
+#endif
 }

--- a/src/icrar/leap-accelerate/CMakeLists.txt
+++ b/src/icrar/leap-accelerate/CMakeLists.txt
@@ -94,6 +94,7 @@ set(cuda_sources
 option(CASA_ENABLED "Casa Enabled" TRUE)
 option(GSL_ENABLED "GSL Enabled" OFF)
 
+if(CUDA_ENABLED)
 add_library(
   ${TARGET_NAME} STATIC
     ${sources}
@@ -102,6 +103,14 @@ add_library(
     ${public_headers}
     ${cuda_headers}
 )
+else()
+add_library(
+  ${TARGET_NAME} STATIC
+    ${sources}
+    ${private_headers}
+    ${public_headers}
+)
+endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
   target_precompile_headers(${TARGET_NAME}
@@ -111,22 +120,23 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
 endif()
 
 
-# Request that the target be built with -std=c++11
-# As this is a public compile feature anything that links to the target
-# will also build with -std=c++11
-target_compile_features(${TARGET_NAME} PUBLIC cxx_std_14)
+if(CUDA_ENABLED)
+  # Request that the target be built with -std=c++11
+  # As this is a public compile feature anything that links to the target
+  # will also build with -std=c++11
+  target_compile_features(${TARGET_NAME} PUBLIC cxx_std_14)
 
-# We need to explicitly state that we need all CUDA files in the target
-# library to be built with -dc as the member functions could be called by
-# other libraries and executables
-set_target_properties(${TARGET_NAME} PROPERTIES CUDA_STANDARD 11)
-#set(CUDA_PROPAGATE_HOST_FLAGS ON)
-#set_target_properties(${TARGET_NAME} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-#set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-gencode arch=compute_60,code=sm_60>)
-target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --display_error_number>)
-configure_cuda_warnings(${TARGET_NAME})
-
+  # We need to explicitly state that we need all CUDA files in the target
+  # library to be built with -dc as the member functions could be called by
+  # other libraries and executables
+  set_target_properties(${TARGET_NAME} PROPERTIES CUDA_STANDARD 11)
+  #set(CUDA_PROPAGATE_HOST_FLAGS ON)
+  #set_target_properties(${TARGET_NAME} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  #set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-gencode arch=compute_60,code=sm_60>)
+  target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe --display_error_number>)
+  configure_cuda_warnings(${TARGET_NAME})
+endif()
 
 #target_link_libraries(${TARGET_NAME} CUDA)
 

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
@@ -30,7 +30,7 @@
 
 #include <icrar/leap-accelerate/model/cpu/Integration.h>
 
-#include <icrar/leap-accelerate/model/casa/MetaData.h>
+#include <icrar/leap-accelerate/model/cpu/MetaData.h>
 #include <icrar/leap-accelerate/model/cuda/DeviceMetaData.h>
 
 #include <icrar/leap-accelerate/common/eigen_extensions.h>

--- a/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h
+++ b/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
@@ -86,3 +88,4 @@ namespace cuda
         DeviceMetaData& metadata);
 }
 }
+#endif // CUDA_ENABLED

--- a/src/icrar/leap-accelerate/core/log/Verbosity.cc
+++ b/src/icrar/leap-accelerate/core/log/Verbosity.cc
@@ -21,6 +21,7 @@
  */
 
 #include <icrar/leap-accelerate/core/log/Verbosity.h>
+#include <icrar/leap-accelerate/exception/exception.h>
 #include <algorithm>
 
 namespace icrar
@@ -32,7 +33,7 @@ namespace log
         Verbosity e;
         if(!TryParseVerbosity(value, e))
         {
-            throw std::invalid_argument("value");
+            throw invalid_argument_exception(value, "value", __FILE__, __LINE__);
         }
         return e;
     }

--- a/src/icrar/leap-accelerate/cuda/cuda_info.h
+++ b/src/icrar/leap-accelerate/cuda/cuda_info.h
@@ -20,6 +20,10 @@
 *    MA 02111-1307  USA
 */
 
+#pragma once
+
+#ifdef CUDA_ENABLED
+
 /**
  * @brief Gets the number of available Cuda Devices
  * 
@@ -31,3 +35,5 @@ int GetCudaDeviceCount();
  * @brief Prints running cuda device info to the output log.
  */
 void printCudaVersion();
+
+#endif // CUDA_ENABLED

--- a/src/icrar/leap-accelerate/cuda/device_matrix.h
+++ b/src/icrar/leap-accelerate/cuda/device_matrix.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
@@ -51,7 +53,6 @@ namespace cuda
         T* m_buffer;
 
     public:
-
         /**
          * @brief Construct a new device buffer object
          * 
@@ -195,3 +196,5 @@ namespace cuda
     };
 }
 }
+
+#endif //CUDA_ENABLED

--- a/src/icrar/leap-accelerate/cuda/device_tensor.h
+++ b/src/icrar/leap-accelerate/cuda/device_tensor.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
@@ -190,3 +192,5 @@ namespace cuda
     };
 }
 }
+
+#endif //CUDA_ENABLED

--- a/src/icrar/leap-accelerate/cuda/device_vector.h
+++ b/src/icrar/leap-accelerate/cuda/device_vector.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
@@ -169,3 +171,5 @@ namespace cuda
     };
 }
 }
+
+#endif //CUDA_ENABLED

--- a/src/icrar/leap-accelerate/math/cuda/vector.h
+++ b/src/icrar/leap-accelerate/math/cuda/vector.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include <icrar/leap-accelerate/cuda/device_vector.h>
 #include <casacore/casa/Arrays/Array.h>
 
@@ -58,3 +60,5 @@ namespace cuda
 
 }
 }
+
+#endif // CUDA_ENABLED

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.h
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.h
@@ -79,7 +79,7 @@ namespace cpu
         double dlm_ra;
         double dlm_dec;
 
-        __device__ __host__ double GetChannelWavelength(int i) const
+        double GetChannelWavelength(int i) const
         {
             return speed_of_light / (freq_start_hz + i * freq_inc_hz);
         }

--- a/src/icrar/leap-accelerate/model/cuda/DeviceIntegration.h
+++ b/src/icrar/leap-accelerate/model/cuda/DeviceIntegration.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include <icrar/leap-accelerate/common/Tensor3X.h>
 #include <icrar/leap-accelerate/common/MVuvw.h>
 #include <icrar/leap-accelerate/common/MVDirection.h>
@@ -115,3 +117,5 @@ namespace cuda
     };
 }
 }
+
+#endif // CUDA_ENABLED

--- a/src/icrar/leap-accelerate/model/cuda/DeviceMetaData.h
+++ b/src/icrar/leap-accelerate/model/cuda/DeviceMetaData.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#ifdef CUDA_ENABLED
+
 #include <icrar/leap-accelerate/common/MVuvw.h>
 #include <icrar/leap-accelerate/common/MVDirection.h>
 
@@ -151,3 +153,5 @@ namespace cuda
     };
 }
 }
+
+#endif // CUDA_ENABLED

--- a/src/icrar/leap-accelerate/tests/algorithm/PhaseRotateTests.cc
+++ b/src/icrar/leap-accelerate/tests/algorithm/PhaseRotateTests.cc
@@ -117,7 +117,9 @@ namespace icrar
             }
             else if(impl == ComputeImplementation::cuda)
             {
+#ifdef CUDA_ENABLED
                 std::tie(integrations, calibrations) = cuda::Calibrate(*ms, ToDirectionVector(directions));
+#endif // CUDA_ENABLED
             }
             else
             {
@@ -189,6 +191,7 @@ namespace icrar
             }
             if(impl == ComputeImplementation::cuda)
             {
+#ifdef CUDA_ENABLED
                 auto integration = icrar::cpu::Integration(
                     0,
                     *ms,
@@ -212,6 +215,7 @@ namespace icrar
                 icrar::cuda::RotateVisibilities(deviceIntegration, deviceMetadata);
                 deviceMetadata.ToHost(hostMetadata);
                 metadataOptionalOutput = hostMetadata;
+#endif // CUDA_ENABLED
             }
 
             ASSERT_TRUE(metadataOptionalOutput.is_initialized());

--- a/src/icrar/leap-accelerate/tests/math/vector_tests.cc
+++ b/src/icrar/leap-accelerate/tests/math/vector_tests.cc
@@ -53,10 +53,12 @@ public:
     {
         if(useCuda)
         {
+#ifdef CUDA_ENABLED
             // See this page: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html
             int deviceCount = 0;
             checkCudaErrors(cudaGetDeviceCount(&deviceCount));
             ASSERT_EQ(1, deviceCount);
+#endif
         }
 
         std::array<int, n> a;
@@ -68,7 +70,9 @@ public:
 
         if(useCuda)
         {
+#ifdef CUDA_ENABLED
             icrar::cuda::add(n, a.data(), b.data(), c.data());
+#endif
         }
         else
         {
@@ -88,7 +92,9 @@ public:
 
         if(useCuda)
         {
+#ifdef CUDA_ENABLED
             icrar::cuda::add(a, b, c);
+#endif
         }
         else
         {
@@ -107,11 +113,13 @@ public:
 
         if(useCuda)
         {
+#ifdef CUDA_ENABLED
             auto d_a = icrar::cuda::device_vector<int>(a);
             auto d_b = icrar::cuda::device_vector<int>(b);
             auto d_c = icrar::cuda::device_vector<int>(c);
             icrar::cuda::add(d_a, d_b, d_c);
             d_c.ToHost(c);
+#endif
         }
         else
         {
@@ -130,6 +138,7 @@ public:
 
         if(useCuda)
         {
+#ifdef CUDA_ENABLED
             auto d_a = icrar::cuda::device_vector<int>(a);
             auto d_b = icrar::cuda::device_vector<int>(b);
             auto d_c = icrar::cuda::device_vector<int>(out);
@@ -144,6 +153,7 @@ public:
                 n2 = n3;
             }
             n3->ToHost(out);
+#endif
         }
         else
         {

--- a/src/icrar/leap-accelerate/tests/model/MetaDataTests.cc
+++ b/src/icrar/leap-accelerate/tests/model/MetaDataTests.cc
@@ -191,6 +191,7 @@ namespace icrar
             EXPECT_DOUBLE_EQ(2.1537588131757608, cpuMetadata.GetConstants().GetChannelWavelength(0));
         }
 
+#ifdef CUDA_ENABLED
         void TestCudaBufferCopy()
         {
             auto meta = icrar::casalib::MetaData(*ms);
@@ -218,6 +219,7 @@ namespace icrar
             
             ASSERT_MDEQ(expectedhostMetadata, hostMetadata, THRESHOLD);
         }
+#endif
     };
 
     TEST_F(MetaDataTests, TestMeasurementSet) { TestMeasurementSet(); }
@@ -225,6 +227,9 @@ namespace icrar
     TEST_F(MetaDataTests, TestReadFromFileOverrideStations) { TestReadFromFileOverrideStations(); }
     TEST_F(MetaDataTests, TestSetWv) { TestSetWv(); }
     TEST_F(MetaDataTests, TestChannelWavelengths) { TestChannelWavelengths(); }
-    TEST_F(MetaDataTests, TestCudaBufferCopy) { TestCudaBufferCopy(); }
     TEST_F(MetaDataTests, TestDD) { TestDD(); }
+
+#ifdef CUDA_ENABLED
+    TEST_F(MetaDataTests, TestCudaBufferCopy) { TestCudaBufferCopy(); }
+#endif
 }

--- a/src/icrar/leap-accelerate/tests/test_helper.h
+++ b/src/icrar/leap-accelerate/tests/test_helper.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <icrar/leap-accelerate/model/cpu/MetaData.h>
 #include <icrar/leap-accelerate/model/cuda/DeviceMetaData.h>
 
 #include <Eigen/Core>


### PR DESCRIPTION
Based on Andreas' requests I've added some trivial support for building without cuda.

For the most part the preprocessors worked for entire file scopes however compute unit tests are a bit polutted and don't correctly handle cases where an implementation is missing from compilation. Ideally I'd refactor this further by moving compute functions to methods of a compute object that can use an interface in unit tests to make them nicer.