### PR TITLE
PhaseMatrix Cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ if(TRACE)
 endif()
 
 add_definitions(-DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/testdata")
-#add_definitions(-DEIGEN_DEFAULT_DENSE_INDEX_TYPE=size_t)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external/cmake-modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(TRACE)
 endif()
 
 add_definitions(-DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/testdata")
+#add_definitions(-DEIGEN_DEFAULT_DENSE_INDEX_TYPE=size_t)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/external/cmake-modules)

--- a/src/icrar/leap-accelerate-cli/Arguments.cc
+++ b/src/icrar/leap-accelerate-cli/Arguments.cc
@@ -348,7 +348,7 @@ namespace icrar
                     }
                     else
                     {
-                        throw json_exception("useFileSystemCache bust be of type bool", __FILE__, __LINE__);
+                        throw json_exception("useFileSystemCache must be of type bool", __FILE__, __LINE__);
                     }
                 }
                 else if(key == "mwaSupport")

--- a/src/icrar/leap-accelerate-cli/Arguments.cc
+++ b/src/icrar/leap-accelerate-cli/Arguments.cc
@@ -45,6 +45,7 @@ namespace icrar
         args.stations = boost::none;
         args.directions = boost::none;
         args.computeImplementation = std::string("cpu");
+        args.useFileSystemCache = true;
         args.mwaSupport = false;
         args.readAutocorrelations = true;
         args.verbosity = static_cast<int>(log::DEFAULT_VERBOSITY);
@@ -56,6 +57,7 @@ namespace icrar
         , filePath(std::move(args.filePath))
         , configFilePath(std::move(args.configFilePath))
         , outputFilePath(std::move(args.outputFilePath))
+        , useFileSystemCache(std::move(args.useFileSystemCache))
         , mwaSupport(std::move(args.mwaSupport))
         , readAutocorrelations(std::move(args.readAutocorrelations))
     {
@@ -183,6 +185,11 @@ namespace icrar
             m_computeImplementation = std::move(args.computeImplementation.get());
         }
 
+        if(args.useFileSystemCache.is_initialized())
+        {
+            m_useFileSystemCache = std::move(args.useFileSystemCache.get());
+        }
+
         if(args.mwaSupport.is_initialized())
         {
             m_mwaSupport = std::move(args.mwaSupport.get());
@@ -228,7 +235,7 @@ namespace icrar
         return *m_measurementSet;
     }
 
-    std::vector<icrar::MVDirection>& ArgumentsValidated::GetDirections()
+    const std::vector<icrar::MVDirection>& ArgumentsValidated::GetDirections() const
     {
         return m_directions;
     }
@@ -236,6 +243,11 @@ namespace icrar
     ComputeImplementation ArgumentsValidated::GetComputeImplementation() const
     {
         return m_computeImplementation;
+    }
+
+    bool ArgumentsValidated::IsFileSystemCacheEnabled() const
+    {
+        return m_useFileSystemCache;
     }
 
     icrar::log::Verbosity ArgumentsValidated::GetVerbosity() const
@@ -326,6 +338,17 @@ namespace icrar
                     else
                     {
                         throw json_exception("invalid compute implementation string", __FILE__, __LINE__);
+                    }
+                }
+                else if(key == "useFileSystemCache")
+                {
+                    if(it->value.IsBool())
+                    {
+                        args.useFileSystemCache = it->value.GetBool();
+                    }
+                    else
+                    {
+                        throw json_exception("useFileSystemCache bust be of type bool", __FILE__, __LINE__);
                     }
                 }
                 else if(key == "mwaSupport")

--- a/src/icrar/leap-accelerate-cli/Arguments.h
+++ b/src/icrar/leap-accelerate-cli/Arguments.h
@@ -62,6 +62,7 @@ namespace icrar
         boost::optional<std::string> stations;
         boost::optional<std::string> directions;
         boost::optional<std::string> computeImplementation;
+        boost::optional<bool> useFileSystemCache;
         boost::optional<bool> mwaSupport;
         boost::optional<bool> readAutocorrelations;
         boost::optional<int> verbosity;
@@ -84,6 +85,7 @@ namespace icrar
         boost::optional<int> stations;
         boost::optional<std::vector<icrar::MVDirection>> directions;
         boost::optional<ComputeImplementation> computeImplementation;
+        boost::optional<bool> useFileSystemCache;
         boost::optional<bool> mwaSupport;
         boost::optional<bool> readAutocorrelations;
         boost::optional<icrar::log::Verbosity> verbosity;
@@ -105,6 +107,7 @@ namespace icrar
         boost::optional<int> m_stations; // Overriden number of stations (will be removed in a later release)
         std::vector<MVDirection> m_directions; // Calibration directions
         ComputeImplementation m_computeImplementation; // Specifies the implementation for calibration computation
+        bool m_useFileSystemCache; // Enables caching of expensive calculations to the filesystem
         bool m_mwaSupport; // Negates baselines when enabled
         bool m_readAutocorrelations; // Adjusts the number of baselines calculation to include autocorrelations
         icrar::log::Verbosity m_verbosity; // Defines logging level for std::out
@@ -138,9 +141,11 @@ namespace icrar
 
         MeasurementSet& GetMeasurementSet();
 
-        std::vector<icrar::MVDirection>& GetDirections();
+        const std::vector<icrar::MVDirection>& GetDirections() const;
 
         ComputeImplementation GetComputeImplementation() const;
+
+        bool IsFileSystemCacheEnabled() const;
 
         icrar::log::Verbosity GetVerbosity() const;
 

--- a/src/icrar/leap-accelerate-cli/main.cc
+++ b/src/icrar/leap-accelerate-cli/main.cc
@@ -85,9 +85,14 @@ int main(int argc, char** argv)
     //TODO: app.add_option("-m,--mwa-support", rawArgs.mwaSupport, "MWA data support by negating baselines");
 
 #if __has_include(<optional>)
+    app.add_option("-u, --useFileSystemCache", rawArgs.useFileSystemCache, "Use filesystem caching between calls");
     app.add_option("-a,--autocorrelations", rawArgs.readAutocorrelations, "Set to true if measurement set rows store autocorrelations");
     app.add_option("-v,--verbosity", rawArgs.verbosity, "Verbosity (0=fatal, 1=error, 2=warn, 3=info, 4=debug, 5=trace), defaults to info");
 #else
+    boost::optional<std::string> useFileSystemCache;
+    app.add_option("-u, --useFileSystemCache", useFileSystemCache, "Use filesystem caching between calls");
+    rawArgs.useFileSystemCache = useFileSystemCache.is_initialized() ? boost::lexical_cast<bool>(useFileSystemCache.get()) : (boost::optional<bool>)boost::none;
+
     boost::optional<std::string> readAutocorrelations;
     app.add_option("-a,--autocorrelations", readAutocorrelations, "Set to true if measurement set rows store autocorrelations");
     rawArgs.readAutocorrelations = readAutocorrelations.is_initialized() ? std::stoi(readAutocorrelations.get()) : (boost::optional<int>)boost::none;
@@ -129,13 +134,13 @@ int main(int argc, char** argv)
         }
         case ComputeImplementation::cpu:
         {
-            cpu::CalibrateResult result = icrar::cpu::Calibrate(args.GetMeasurementSet(), args.GetDirections());
+            cpu::CalibrateResult result = icrar::cpu::Calibrate(args.GetMeasurementSet(), args.GetDirections(), args.IsFileSystemCacheEnabled());
             cpu::PrintResult(result, args.GetOutputStream());
             break;
         }
         case ComputeImplementation::cuda:
         {
-            cpu::CalibrateResult result = icrar::cuda::Calibrate(args.GetMeasurementSet(), args.GetDirections());
+            cpu::CalibrateResult result = icrar::cuda::Calibrate(args.GetMeasurementSet(), args.GetDirections(), args.IsFileSystemCacheEnabled());
             cpu::PrintResult(result ,args.GetOutputStream());
             break;
         }

--- a/src/icrar/leap-accelerate-cli/tests/E2EPerformanceTests.cc
+++ b/src/icrar/leap-accelerate-cli/tests/E2EPerformanceTests.cc
@@ -104,11 +104,11 @@ namespace icrar
             }
             else if(impl == ComputeImplementation::cpu)
             {
-                auto output = cpu::Calibrate(*ms, ToDirectionVector(directions));
+                auto output = cpu::Calibrate(*ms, ToDirectionVector(directions), false);
             }
             else if(impl == ComputeImplementation::cuda)
             {
-                auto result = cuda::Calibrate(*ms, ToDirectionVector(directions));
+                auto result = cuda::Calibrate(*ms, ToDirectionVector(directions), false);
             }
             else
             {

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseMatrixFunction.h
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseMatrixFunction.h
@@ -40,7 +40,9 @@ namespace cpu
      * @param a2 indexes of 2nd antenna of each baselines
      * @param refAnt the reference antenna (0, 1), -1 
      * @param map 
-     * @return std::pair<Matrixd, Matrixi> 
+     * @return std::pair<Matrixd, Matrixi>
+     * for refAnt=-1: first matrix is of size [baselines,stations] and seconds of size[baselines,1]
+     * for refAnt>-1: first matrix is of size [stations,stations] and seconds of size[stations,1]
      */
     std::pair<Eigen::MatrixXd, Eigen::VectorXi> PhaseMatrixFunction(
         const Eigen::VectorXi& a1,

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
@@ -87,7 +87,7 @@ namespace cpu
 
         profiling::timer integration_read_timer;
 
-        unsigned int integrationNumber = 0;
+        constexpr unsigned int integrationNumber = 0;
 
         // Flooring to remove incomplete measurements
         int integrations = ms.GetNumRows() / ms.GetNumBaselines();

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.cc
@@ -67,7 +67,8 @@ namespace cpu
 {
     CalibrateResult Calibrate(
         const icrar::MeasurementSet& ms,
-        const std::vector<icrar::MVDirection>& directions)
+        const std::vector<icrar::MVDirection>& directions,
+        bool isFileSystemCacheEnabled)
     {
         LOG(info) << "Starting Calibration using cpu";
         LOG(info)
@@ -119,7 +120,7 @@ namespace cpu
 
         profiling::timer metadata_read_timer;
         LOG(info) << "Loading MetaData";
-        auto metadata = icrar::cpu::MetaData(ms, integration.GetUVW());
+        auto metadata = icrar::cpu::MetaData(ms, integration.GetUVW(), isFileSystemCacheEnabled);
         LOG(info) << "Read metadata in " << metadata_read_timer;
 
         profiling::timer phase_rotate_timer;

--- a/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.h
+++ b/src/icrar/leap-accelerate/algorithm/cpu/PhaseRotate.h
@@ -73,7 +73,8 @@ namespace cpu
      */
     CalibrateResult Calibrate(
         const icrar::MeasurementSet& ms,
-        const std::vector<MVDirection>& directions);
+        const std::vector<MVDirection>& directions,
+        bool isFileSystemCacheEnabled);
 
     /**
      * @brief 

--- a/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.cu
+++ b/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.cu
@@ -71,7 +71,8 @@ namespace cuda
 {
     cpu::CalibrateResult Calibrate(
         const icrar::MeasurementSet& ms,
-        const std::vector<icrar::MVDirection>& directions)
+        const std::vector<icrar::MVDirection>& directions,
+        bool isFileSystemCacheEnabled)
     {
         LOG(info) << "Starting Calibration using cuda";
         LOG(info)
@@ -121,7 +122,7 @@ namespace cuda
 
         profiling::timer metadata_read_timer;
         LOG(info) << "Loading MetaData";
-        auto metadata = icrar::cpu::MetaData(ms, integration.GetUVW());
+        auto metadata = icrar::cpu::MetaData(ms, integration.GetUVW(), isFileSystemCacheEnabled);
         auto constantMetadata = std::make_shared<ConstantMetaData>(
             metadata.GetConstants(),
             metadata.GetA(),

--- a/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h
+++ b/src/icrar/leap-accelerate/algorithm/cuda/PhaseRotate.h
@@ -68,7 +68,8 @@ namespace cuda
      */
     cpu::CalibrateResult Calibrate(
         const MeasurementSet& ms,
-        const std::vector<MVDirection>& directions);
+        const std::vector<MVDirection>& directions,
+        bool isFileSystemCacheEnabled);
 
     /**
      * Performs only visibilities rotation on the GPU

--- a/src/icrar/leap-accelerate/common/eigen_extensions.h
+++ b/src/icrar/leap-accelerate/common/eigen_extensions.h
@@ -139,9 +139,9 @@ namespace icrar
         Lambda transform)
     {
         bool cacheRead = false;
-        size_t fileHash = 0;
         try
         {
+            size_t fileHash = 0;
             read_hash(hashFile.c_str(), fileHash);
             if(fileHash == hash)
             {

--- a/src/icrar/leap-accelerate/common/eigen_extensions.h
+++ b/src/icrar/leap-accelerate/common/eigen_extensions.h
@@ -38,6 +38,111 @@ constexpr int pretty_width = 12;
 
 namespace icrar
 {
+    /**
+     * @brief Hash function for Eigen matrix and vector.
+     * The code is from `hash_combine` function of the Boost library. See
+     * http://www.boost.org/doc/libs/1_55_0/doc/html/hash/reference.html#boost.hash_combine .
+     * 
+     * @tparam T 
+     */
+    template<typename T>
+    struct matrix_hash : std::unary_function<T, size_t>
+    {
+        std::size_t operator()(const T& matrix) const
+        {
+            // Note that it is oblivious to the storage order of Eigen matrix (column- or
+            // row-major). It will give you the same hash value for two different matrices if they
+            // are the transpose of each other in different storage order.
+            size_t seed = 0;
+            for (Eigen::Index i = 0; i < matrix.size(); ++i)
+            {
+                auto elem = *(matrix.data() + i);
+                seed ^= std::hash<typename T::Scalar>()(elem) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            }
+            return seed;
+        }
+    };
+
+    template<class Matrix>
+    void write_binary(const char* filename, const Matrix& matrix)
+    {
+        std::ofstream out(filename, std::ios::out | std::ios::binary | std::ios::trunc);
+        typename Matrix::Index rows = matrix.rows(), cols = matrix.cols();
+        out.write((char*) (&rows), sizeof(typename Matrix::Index));
+        out.write((char*) (&cols), sizeof(typename Matrix::Index));
+        out.write((char*) matrix.data(), rows * cols * sizeof(typename Matrix::Scalar) );
+        LOG(info) << "writing " << rows * cols * sizeof(typename Matrix::Scalar);
+        out.close();
+    }
+
+    template<class Matrix>
+    void read_binary(const char* filename, Matrix& matrix)
+    {
+        std::ifstream in(filename, std::ios::in | std::ios::binary);
+        typename Matrix::Index rows = 0, cols = 0;
+        in.read((char*) (&rows),sizeof(typename Matrix::Index));
+        in.read((char*) (&cols),sizeof(typename Matrix::Index));
+        matrix.resize(rows, cols);
+        in.read( (char *) matrix.data() , rows * cols * sizeof(typename Matrix::Scalar) );
+        in.close();
+    }
+
+
+    template<typename T>
+    void read_hash(const char* filename, T& hash)
+    {
+        std::ifstream hashIn(filename, std::ios::in | std::ios::binary);
+        if(hashIn.good())
+        {
+            hashIn.read((char*)(&hash), sizeof(T));
+        }
+    }
+
+    template<typename T>
+    void write_hash(const char* filename, T hash)
+    {
+        std::ofstream hashOut(filename, std::ios::out | std::ios::binary);
+        if(hashOut.good())
+        {
+            hashOut.write((char*)(&hash), sizeof(T));
+        }
+    }
+
+    /**
+     * @brief Reads the file file hash and writes to cache if hash file is different
+     * or reads the cache if hash file is the same. 
+     * 
+     * @tparam Matrix 
+     * @tparam R 
+     * @param in The input matrix to hash and transform
+     * @param out The transformed output
+     * @param transform the transform lambda
+     * @param cacheFile the transformed cache file
+     * @param hashFile the input hash file
+     */
+    template<typename In, typename Out>
+    void ProcessCache(size_t hash,
+        const In& in, Out& out,
+        std::string cacheFile, std::string hashFile,
+        std::function<Out(const In&)> transform)
+    {
+        size_t fileHash;
+        read_hash(hashFile.c_str(), fileHash);
+        if(fileHash == hash)
+        {
+            LOG(info) << "Reading cache from " << cacheFile;
+            read_binary(cacheFile.c_str(), out);
+        }
+        else
+        {
+            out = transform(in);
+            LOG(info) << "Writing cache to " << cacheFile;
+            write_hash(hashFile.c_str(), hash);
+            write_binary(cacheFile.c_str(), out);
+        }
+
+    }
+
     template<typename RowVector>
     void pretty_row(const RowVector& row, std::stringstream& ss)
     {

--- a/src/icrar/leap-accelerate/common/eigen_extensions.h
+++ b/src/icrar/leap-accelerate/common/eigen_extensions.h
@@ -123,7 +123,7 @@ namespace icrar
     template<typename In, typename Out>
     void ProcessCache(size_t hash,
         const In& in, Out& out,
-        std::string cacheFile, std::string hashFile,
+        std::string hashFile, std::string cacheFile,
         std::function<Out(const In&)> transform)
     {
         size_t fileHash;
@@ -140,7 +140,6 @@ namespace icrar
             write_hash(hashFile.c_str(), hash);
             write_binary(cacheFile.c_str(), out);
         }
-
     }
 
     template<typename RowVector>

--- a/src/icrar/leap-accelerate/model/casa/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/casa/MetaData.cc
@@ -240,7 +240,6 @@ namespace casalib
         && icrar::Equal(A1, rhs.A1)
         && icrar::Equal(I1, rhs.I1)
         && icrar::Equal(Ad1, rhs.Ad1);
-
     }
 }
 }

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -130,15 +130,6 @@ namespace cpu
         casacore::Vector<std::int32_t> a1 = msmc->antenna1().getColumnRange(epochIndices);
         casacore::Vector<std::int32_t> a2 = msmc->antenna2().getColumnRange(epochIndices);
 
-        // if(a1.size() != m_constants.nbaselines)
-        // {
-        //     throw std::runtime_error("incorrect antenna size");
-        // }
-        // if(a2.size() != m_constants.nbaselines)
-        // {
-        //     throw std::runtime_error("incorrect antenna size");
-        // }
-
         LOG(info) << "Calculating PhaseMatrix A1";
         std::tie(m_A1, m_I1) = icrar::cpu::PhaseMatrixFunction(ToVector(a1), ToVector(a2), 0);
         trace_matrix(m_A1, "A1");
@@ -159,15 +150,10 @@ namespace cpu
             return icrar::cpu::PseudoInverse(a);
         };
 
+
+        m_Ad1 = computeAd1(m_A1);
         if(useCache)
         {
-            //cache Ad1 with A1 hash
-            ProcessCache<Eigen::MatrixXd, Eigen::MatrixXd>(
-                matrix_hash<Eigen::MatrixXd>()(m_A1),
-                m_A1, m_Ad1,
-                "A1.hash", "Ad1.cache",
-                computeAd1);
-        
             //cache Ad with A hash
             ProcessCache<Eigen::MatrixXd, Eigen::MatrixXd>(
                 matrix_hash<Eigen::MatrixXd>()(m_A),
@@ -177,7 +163,6 @@ namespace cpu
         }
         else
         {
-            m_Ad1 = computeAd1(m_A1);
             m_Ad = computeAd(m_A);
         }
 

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -139,21 +139,18 @@ namespace cpu
         trace_matrix(m_A, "A");
 
 
-        auto invertAd1 = [](const Eigen::MatrixXd& a)
+        auto invertA1 = [](const Eigen::MatrixXd& a)
         {
             LOG(info) << "Inverting PhaseMatrix A1";
             return icrar::cpu::PseudoInverse(a);
         };
-        auto invertAd = [](const Eigen::MatrixXd& a)
+        auto invertA = [](const Eigen::MatrixXd& a)
         {
             LOG(info) << "Inverting PhaseMatrix A";
             return icrar::cpu::PseudoInverse(a);
         };
 
-        // Not large enough to cache
-        m_Ad1 = invertAd1(m_A1);
-
-        // Use cache if available
+        m_Ad1 = invertA1(m_A1);
         if(useCache)
         {
             //cache Ad with A hash
@@ -161,11 +158,11 @@ namespace cpu
                 matrix_hash<Eigen::MatrixXd>()(m_A),
                 m_A, m_Ad,
                 "A.hash", "Ad.cache",
-                invertAd);
+                invertA);
         }
         else
         {
-            m_Ad = invertAd(m_A);
+            m_Ad = invertA(m_A);
         }
 
         trace_matrix(m_Ad1, "Ad1");

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.cc
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.cc
@@ -139,19 +139,21 @@ namespace cpu
         trace_matrix(m_A, "A");
 
 
-        auto computeAd1 = [](const Eigen::MatrixXd& a)
+        auto invertAd1 = [](const Eigen::MatrixXd& a)
         {
             LOG(info) << "Inverting PhaseMatrix A1";
             return icrar::cpu::PseudoInverse(a);
         };
-        auto computeAd = [](const Eigen::MatrixXd& a)
+        auto invertAd = [](const Eigen::MatrixXd& a)
         {
             LOG(info) << "Inverting PhaseMatrix A";
             return icrar::cpu::PseudoInverse(a);
         };
 
+        // Not large enough to cache
+        m_Ad1 = invertAd1(m_A1);
 
-        m_Ad1 = computeAd1(m_A1);
+        // Use cache if available
         if(useCache)
         {
             //cache Ad with A hash
@@ -159,11 +161,11 @@ namespace cpu
                 matrix_hash<Eigen::MatrixXd>()(m_A),
                 m_A, m_Ad,
                 "A.hash", "Ad.cache",
-                computeAd);
+                invertAd);
         }
         else
         {
-            m_Ad = computeAd(m_A);
+            m_Ad = invertAd(m_A);
         }
 
         trace_matrix(m_Ad1, "Ad1");

--- a/src/icrar/leap-accelerate/model/cpu/MetaData.h
+++ b/src/icrar/leap-accelerate/model/cpu/MetaData.h
@@ -115,7 +115,7 @@ namespace cpu
          * @param ms 
          * @param uvws 
          */
-        MetaData(const icrar::MeasurementSet& ms, const std::vector<icrar::MVuvw>& uvws);
+        MetaData(const icrar::MeasurementSet& ms, const std::vector<icrar::MVuvw>& uvws, bool useCache = true);
 
         /**
          * @brief Construct a new MetaData object
@@ -124,7 +124,7 @@ namespace cpu
          * @param direction 
          * @param uvws 
          */
-        MetaData(const icrar::MeasurementSet& ms, const icrar::MVDirection& direction, const std::vector<icrar::MVuvw>& uvws);
+        MetaData(const icrar::MeasurementSet& ms, const icrar::MVDirection& direction, const std::vector<icrar::MVuvw>& uvws, bool useCache = true);
         
         /**
          * @brief Constructs a MetaData object from an equivalent casa MetaData object

--- a/src/icrar/leap-accelerate/tests/algorithm/PhaseRotateTests.cc
+++ b/src/icrar/leap-accelerate/tests/algorithm/PhaseRotateTests.cc
@@ -113,11 +113,11 @@ namespace icrar
             }
             else if(impl == ComputeImplementation::cpu)
             {
-                std::tie(integrations, calibrations) = cpu::Calibrate(*ms, ToDirectionVector(directions));
+                std::tie(integrations, calibrations) = cpu::Calibrate(*ms, ToDirectionVector(directions), false);
             }
             else if(impl == ComputeImplementation::cuda)
             {
-                std::tie(integrations, calibrations) = cuda::Calibrate(*ms, ToDirectionVector(directions));
+                std::tie(integrations, calibrations) = cuda::Calibrate(*ms, ToDirectionVector(directions), false);
             }
             else
             {


### PR DESCRIPTION
https://jira.skatelescope.org/browse/YAN-553
Calculating Ad is expensive for SKA as the matrix size is ~(stations^3)/2 * 8 (512 MiB) I've added a caching technique using the hash of the A and A1 matrix that loads in ~5s from SSD as opposed to ~51s with computation.